### PR TITLE
feat: enhance service initialization and configuration loading

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ build:clean
 .PHONY: format
 format:
 	@echo "  ->  Formatting code"
-
+	golangci-lint run  --disable-all -E errcheck -E staticcheck
 .PHONY: test
 test:
 	CGO_ENABLED=1 go test -v -race ./...

--- a/cli/cmd/config.go
+++ b/cli/cmd/config.go
@@ -56,7 +56,7 @@ func ConfigCommandFunc(command *cobra.Command, args []string) error {
 
 	// 当前配置文件检测
 	hasConfig := false
-	nowConfig := []byte{}
+	var nowConfig []byte
 	nowConfigJson := make(map[string]interface{})
 	configFilePath := filepath.Join(mlConfig.BasePath, mlConfig.ConfigFile)
 	if nowConfig, err = os.ReadFile(configFilePath); err == nil {

--- a/cli/cmd/config.go
+++ b/cli/cmd/config.go
@@ -44,6 +44,7 @@ var (
 
 // ConfigCommandFunc executes the "config" command.
 func ConfigCommandFunc(command *cobra.Command, args []string) error {
+	var err error
 	logger := initLogger(mlConfig.BasePath)
 	consoleWriter := zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: time.RFC3339}
 	multi := zerolog.MultiLevelWriter(consoleWriter, logger)
@@ -52,6 +53,22 @@ func ConfigCommandFunc(command *cobra.Command, args []string) error {
 	logger.Info().Msg("Start to show config")
 	ctx := context.WithValue(context.Background(), services.MoLingConfigKey, mlConfig)
 	ctx = context.WithValue(ctx, services.MoLingLoggerKey, logger)
+
+	// 当前配置文件检测
+	hasConfig := false
+	nowConfig := []byte{}
+	nowConfigJson := make(map[string]interface{})
+	configFilePath := filepath.Join(mlConfig.BasePath, mlConfig.ConfigFile)
+	if nowConfig, err = os.ReadFile(configFilePath); err == nil {
+		hasConfig = true
+	}
+	if hasConfig {
+		err = json.Unmarshal(nowConfig, &nowConfigJson)
+		if err != nil {
+			return fmt.Errorf("Error unmarshaling JSON: %v, payload:%s\n", err, string(nowConfig))
+		}
+	}
+
 	bf := bytes.Buffer{}
 	bf.WriteString("\n{\n")
 
@@ -63,10 +80,25 @@ func ConfigCommandFunc(command *cobra.Command, args []string) error {
 	bf.WriteString("\t\"MoLingConfig\":\n")
 	bf.WriteString(fmt.Sprintf("\t%s,\n", mlConfigJson))
 	first := true
-	for _, nsv := range services.ServiceList() {
-		srv, err := nsv(ctx, args)
+	for srvName, nsv := range services.ServiceList() {
+		// 获取服务对应的配置
+		cfg, ok := nowConfigJson[srvName].(map[string]interface{})
+
+		srv, err := nsv(ctx)
 		if err != nil {
 			return err
+		}
+		// srv Loadconfig
+		if ok {
+			err = srv.LoadConfig(cfg)
+			if err != nil {
+				return fmt.Errorf("Error loading config for service %s: %v\n", srv.Name(), err)
+			}
+		}
+		// srv Init
+		err = srv.Init()
+		if err != nil {
+			return fmt.Errorf("Error initializing service %s: %v\n", srv.Name(), err)
 		}
 		if !first {
 			bf.WriteString(",\n")
@@ -80,7 +112,7 @@ func ConfigCommandFunc(command *cobra.Command, args []string) error {
 	var data interface{}
 	err = json.Unmarshal(bf.Bytes(), &data)
 	if err != nil {
-		return fmt.Errorf("Error unmarshaling JSON: %v\n", err)
+		return fmt.Errorf("Error unmarshaling JSON: %v, payload:%s\n", err, bf.String())
 	}
 
 	// 格式化 JSON
@@ -89,9 +121,8 @@ func ConfigCommandFunc(command *cobra.Command, args []string) error {
 		return fmt.Errorf("Error marshaling JSON: %v\n", err)
 	}
 
-	// 判断是否存在配置文件
-	configFilePath := filepath.Join(mlConfig.BasePath, mlConfig.ConfigFile)
-	if _, err = os.Stat(configFilePath); os.IsNotExist(err) {
+	// 如果不存在配置文件
+	if !hasConfig {
 		logger.Info().Msgf("Configuration file %s does not exist. Creating a new one.", configFilePath)
 		err = os.WriteFile(configFilePath, formattedJson, 0644)
 		if err != nil {

--- a/cli/cmd/moling_test.go
+++ b/cli/cmd/moling_test.go
@@ -38,9 +38,13 @@ func TestNewMLServer(t *testing.T) {
 	ctx := context.WithValue(context.Background(), services.MoLingConfigKey, mlConfig)
 	ctx = context.WithValue(ctx, services.MoLingLoggerKey, loger)
 	// Create a new server with the filesystem service
-	fs, err := services.NewFilesystemServer(ctx, []string{"/tmp/"})
+	fs, err := services.NewFilesystemServer(ctx)
 	if err != nil {
 		t.Errorf("Failed to create filesystem server: %v", err)
+	}
+	err = fs.Init()
+	if err != nil {
+		t.Errorf("Failed to initialize filesystem server: %v", err)
 	}
 	srvs := []services.Service{
 		fs,

--- a/cli/cmd/moling_test.go
+++ b/cli/cmd/moling_test.go
@@ -22,12 +22,12 @@ import (
 )
 
 func TestNewMLServer(t *testing.T) {
-	err := CreateDirectory(mlConfig.BasePath)
+	err := services.CreateDirectory(mlConfig.BasePath)
 	if err != nil {
 		t.Errorf("Failed to create base directory: %v", err)
 	}
 	for _, dirName := range mlDirectories {
-		err = CreateDirectory(filepath.Join(mlConfig.BasePath, dirName))
+		err = services.CreateDirectory(filepath.Join(mlConfig.BasePath, dirName))
 		if err != nil {
 			t.Errorf("Failed to create directory %s: %v", dirName, err)
 		}

--- a/cli/cmd/perrun.go
+++ b/cli/cmd/perrun.go
@@ -17,18 +17,19 @@
 package cmd
 
 import (
+	"github.com/gojue/moling/services"
 	"github.com/spf13/cobra"
 	"path/filepath"
 )
 
 // mlsCommandPreFunc is a pre-run function for the MoLing command.
 func mlsCommandPreFunc(cmd *cobra.Command, args []string) error {
-	err := CreateDirectory(mlConfig.BasePath)
+	err := services.CreateDirectory(mlConfig.BasePath)
 	if err != nil {
 		return err
 	}
 	for _, dirName := range mlDirectories {
-		err = CreateDirectory(filepath.Join(mlConfig.BasePath, dirName))
+		err = services.CreateDirectory(filepath.Join(mlConfig.BasePath, dirName))
 		if err != nil {
 			return err
 		}

--- a/cli/cmd/utils.go
+++ b/cli/cmd/utils.go
@@ -1,19 +1,1 @@
 package cmd
-
-import "os"
-
-// CreateDirectory checks if a directory exists, and creates it if it doesn't
-func CreateDirectory(path string) error {
-	_, err := os.Stat(path)
-	if err != nil {
-		if os.IsNotExist(err) {
-			err = os.MkdirAll(path, 0o755)
-			if err != nil {
-				return err
-			}
-		} else {
-			return err
-		}
-	}
-	return nil
-}

--- a/services/browser.go
+++ b/services/browser.go
@@ -32,7 +32,8 @@ import (
 )
 
 const (
-	BrowserDataPath = "browser" // Path to store browser data
+	BrowserServerName = "BrowserServer"
+	BrowserDataPath   = "browser" // Path to store browser data
 )
 
 // BrowserServer represents the configuration for the browser service.
@@ -40,58 +41,66 @@ type BrowserServer struct {
 	MLService
 	config *BrowserConfig
 	name   string // The name of the service
-	ctx    context.Context
 	cancel context.CancelFunc
 }
 
 // NewBrowserServer creates a new BrowserServer instance with the given context and configuration.
-func NewBrowserServer(ctx context.Context, args []string) (Service, error) {
-
+func NewBrowserServer(ctx context.Context) (Service, error) {
 	bc := NewBrowserConfig()
 	globalConf := ctx.Value(MoLingConfigKey).(*MoLingConfig)
-	userDataDir := filepath.Join(globalConf.BasePath, BrowserDataPath)
-
+	bc.BrowserDataPath = filepath.Join(globalConf.BasePath, BrowserDataPath)
 	bc.DataPath = filepath.Join(globalConf.BasePath, "data")
 	logger, ok := ctx.Value(MoLingLoggerKey).(zerolog.Logger)
 	if !ok {
 		return nil, fmt.Errorf("BrowserServer: invalid logger type: %T", ctx.Value(MoLingLoggerKey))
 	}
-
 	loggerNameHook := zerolog.HookFunc(func(e *zerolog.Event, level zerolog.Level, msg string) {
-		e.Str("Service", "BrowserServer")
+		e.Str("Service", BrowserServerName)
+	})
+	bs := &BrowserServer{
+		MLService: NewMLService(ctx, logger.Hook(loggerNameHook), globalConf),
+		config:    bc,
+	}
+
+	err := bs.init()
+	if err != nil {
+		return nil, err
+	}
+
+	return bs, nil
+}
+
+// Init() initializes the browser server by creating a new context.
+func (bs *BrowserServer) Init() error {
+	loggerNameHook := zerolog.HookFunc(func(e *zerolog.Event, level zerolog.Level, msg string) {
+		e.Str("Service", bs.Name())
 	})
 
-	bs := &BrowserServer{
-		config: bc,
-	}
-	bs.logger = logger.Hook(loggerNameHook)
+	bs.logger = bs.logger.Hook(loggerNameHook)
 
-	err := bs.initBrowser(userDataDir)
+	err := bs.initBrowser(bs.config.BrowserDataPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to initialize browser: %v", err)
+		return fmt.Errorf("failed to initialize browser: %v", err)
 	}
 	// Create a new context for the browser
 	opts := append(
 		chromedp.DefaultExecAllocatorOptions[:],
-		chromedp.UserAgent(bc.UserAgent),
-		chromedp.Flag("lang", bc.DefaultLanguage),
+		chromedp.UserAgent(bs.config.UserAgent),
+		chromedp.Flag("lang", bs.config.DefaultLanguage),
 
 		chromedp.Flag("headless", false),
 		// Like in Puppeteer.
 		chromedp.Flag("hide-scrollbars", false),
 		chromedp.Flag("mute-audio", true),
-		chromedp.CombinedOutput(logger),
+		chromedp.CombinedOutput(bs.logger),
 		chromedp.WindowSize(1312, 848),
-		chromedp.UserDataDir(userDataDir),
+		chromedp.UserDataDir(bs.config.DataPath),
 		chromedp.IgnoreCertErrors,
 	)
-	bs.ctx, bs.cancel = chromedp.NewExecAllocator(ctx, opts...)
+	bs.ctx, bs.cancel = chromedp.NewExecAllocator(bs.ctx, opts...)
 
-	bs.ctx, bs.cancel = chromedp.NewContext(bs.ctx, chromedp.WithErrorf(logger.Printf))
-	err = bs.init()
-	if err != nil {
-		return nil, err
-	}
+	bs.ctx, bs.cancel = chromedp.NewContext(bs.ctx, chromedp.WithErrorf(bs.logger.Printf))
+
 	bs.AddTool(mcp.NewTool(
 		"browser_navigate",
 		mcp.WithDescription("Navigate to a URL"),
@@ -165,7 +174,7 @@ func NewBrowserServer(ctx context.Context, args []string) (Service, error) {
 			mcp.Required(),
 		),
 	), bs.handleEvaluate)
-	return bs, nil
+	return nil
 }
 
 func (bs *BrowserServer) handleNavigate(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -328,19 +337,28 @@ func (bs *BrowserServer) Close() error {
 }
 
 // Config returns the configuration of the service as a string.
-func (mls *BrowserServer) Config() string {
-	cfg, err := json.Marshal(mls.config)
+func (bs *BrowserServer) Config() string {
+	cfg, err := json.Marshal(bs.config)
 	if err != nil {
-		mls.logger.Err(err).Msg("failed to marshal config")
+		bs.logger.Err(err).Msg("failed to marshal config")
 		return "{}"
 	}
 	return string(cfg)
 }
 
-func (cs *BrowserServer) Name() string {
-	return "BrowserServer"
+func (bs *BrowserServer) Name() string {
+	return BrowserServerName
+}
+
+// LoadConfig loads the configuration from a JSON object.
+func (bs *BrowserServer) LoadConfig(jsonData map[string]interface{}) error {
+	err := mergeJSONToStruct(bs.config, jsonData)
+	if err != nil {
+		return err
+	}
+	return bs.config.Check()
 }
 
 func init() {
-	RegisterServ(NewBrowserServer)
+	RegisterServ(BrowserServerName, NewBrowserServer)
 }

--- a/services/browser.go
+++ b/services/browser.go
@@ -77,10 +77,13 @@ func (bs *BrowserServer) Init() error {
 	})
 
 	bs.logger = bs.logger.Hook(loggerNameHook)
-
 	err := bs.initBrowser(bs.config.BrowserDataPath)
 	if err != nil {
 		return fmt.Errorf("failed to initialize browser: %v", err)
+	}
+	err = CreateDirectory(bs.config.DataPath)
+	if err != nil {
+		return fmt.Errorf("failed to create data directory: %v", err)
 	}
 	// Create a new context for the browser
 	opts := append(
@@ -94,7 +97,7 @@ func (bs *BrowserServer) Init() error {
 		chromedp.Flag("mute-audio", true),
 		chromedp.CombinedOutput(bs.logger),
 		chromedp.WindowSize(1312, 848),
-		chromedp.UserDataDir(bs.config.DataPath),
+		chromedp.UserDataDir(bs.config.BrowserDataPath),
 		chromedp.IgnoreCertErrors,
 	)
 	bs.ctx, bs.cancel = chromedp.NewExecAllocator(bs.ctx, opts...)

--- a/services/browser_config.go
+++ b/services/browser_config.go
@@ -31,7 +31,8 @@ type BrowserConfig struct {
 	DefaultLanguage string `json:"default_language"`
 	URLTimeout      int    `json:"url_timeout"`
 	CSSTimeout      int    `json:"css_timeout"`
-	DataPath        string `json:"data_path"` // DataPath is the path to the data directory.
+	DataPath        string `json:"data_path"`         // DataPath is the path to the data directory.
+	BrowserDataPath string `json:"browser_data_path"` // BrowserDataPath is the path to the browser data directory.
 	//logger          *zerolog.Logger
 }
 
@@ -55,7 +56,7 @@ func NewBrowserConfig() *BrowserConfig {
 		Timeout:         30,
 		URLTimeout:      10,
 		CSSTimeout:      10,
-		UserAgent:       "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3 (GoJue MoLing)",
+		UserAgent:       "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3",
 		DefaultLanguage: "en-US",
 		DataPath:        filepath.Join(os.TempDir(), ".moling", "data"),
 	}

--- a/services/browser_test.go
+++ b/services/browser_test.go
@@ -59,7 +59,8 @@ func TestBrowserServer(t *testing.T) {
 		t.Fatalf("Failed to initialize test environment: %v", err)
 	}
 	logger.Info().Msg("TestBrowserServer")
-	_, err = NewBrowserServer(ctx, []string{"--headless"})
+
+	_, err = NewBrowserServer(ctx)
 	if err != nil {
 		t.Fatalf("Failed to create BrowserServer: %v", err)
 	}

--- a/services/command.go
+++ b/services/command.go
@@ -79,10 +79,6 @@ func NewCommandServer(ctx context.Context) (Service, error) {
 
 func (cs *CommandServer) Init() error {
 	var err error
-	//err := cs.LoadConfig(cs.config, cfg)
-	//if err != nil {
-	//	return err
-	//}
 
 	pe := PromptEntry{
 		prompt: mcp.Prompt{

--- a/services/command.go
+++ b/services/command.go
@@ -34,6 +34,10 @@ var (
 	ErrCommandNotAllowed = fmt.Errorf("command not allowed")
 )
 
+const (
+	CommandServerName = "CommandServer"
+)
+
 // CommandServer implements the Service interface and provides methods to execute named commands.
 type CommandServer struct {
 	MLService
@@ -43,9 +47,9 @@ type CommandServer struct {
 }
 
 // NewCommandServer creates a new CommandServer with the given allowed commands.
-func NewCommandServer(ctx context.Context, args []string) (Service, error) {
+func NewCommandServer(ctx context.Context) (Service, error) {
 	var err error
-	cc := NewCommandConfig(args)
+	cc := NewCommandConfig()
 	gConf, ok := ctx.Value(MoLingConfigKey).(*MoLingConfig)
 	if !ok {
 		return nil, fmt.Errorf("CommandServer: invalid config type")
@@ -57,22 +61,28 @@ func NewCommandServer(ctx context.Context, args []string) (Service, error) {
 	}
 
 	loggerNameHook := zerolog.HookFunc(func(e *zerolog.Event, level zerolog.Level, msg string) {
-		e.Str("Service", "CommandServer")
+		e.Str("Service", CommandServerName)
 	})
 
 	cs := &CommandServer{
-		MLService: MLService{
-			ctx:      ctx,
-			logger:   lger.Hook(loggerNameHook),
-			mlConfig: gConf,
-		},
-		config: cc,
+		MLService: NewMLService(ctx, lger.Hook(loggerNameHook), gConf),
+		config:    cc,
 	}
 
 	err = cs.init()
 	if err != nil {
 		return nil, err
 	}
+
+	return cs, nil
+}
+
+func (cs *CommandServer) Init() error {
+	var err error
+	//err := cs.LoadConfig(cs.config, cfg)
+	//if err != nil {
+	//	return err
+	//}
 
 	pe := PromptEntry{
 		prompt: mcp.Prompt{
@@ -91,8 +101,7 @@ func NewCommandServer(ctx context.Context, args []string) (Service, error) {
 			mcp.Required(),
 		),
 	), cs.handleExecuteCommand)
-
-	return cs, nil
+	return err
 }
 
 func (cs *CommandServer) handlePrompt(ctx context.Context, request mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
@@ -134,9 +143,8 @@ func (cs *CommandServer) handleExecuteCommand(ctx context.Context, request mcp.C
 
 // isAllowedCommand checks if the command is allowed based on the configuration.
 func (cs *CommandServer) isAllowedCommand(command string) bool {
-
 	// 检查命令是否在允许的列表中
-	for _, allowed := range cs.config.AllowedCommands {
+	for _, allowed := range cs.config.allowedCommands {
 		if strings.HasPrefix(command, allowed) {
 			return true
 		}
@@ -159,6 +167,7 @@ func (cs *CommandServer) isAllowedCommand(command string) bool {
 
 // Config returns the configuration of the service as a string.
 func (cs *CommandServer) Config() string {
+	cs.config.AllowedCommand = strings.Join(cs.config.allowedCommands, ",")
 	cfg, err := json.Marshal(cs.config)
 	if err != nil {
 		cs.logger.Err(err).Msg("failed to marshal config")
@@ -169,15 +178,26 @@ func (cs *CommandServer) Config() string {
 }
 
 func (cs *CommandServer) Name() string {
-	return "CommandServer"
+	return CommandServerName
 }
 
-func (bs *CommandServer) Close() error {
+func (cs *CommandServer) Close() error {
 	// Cancel the context to stop the browser
-	bs.logger.Debug().Msg("CommandServer closed")
+	cs.logger.Debug().Msg("CommandServer closed")
 	return nil
 }
 
+// LoadConfig loads the configuration from a JSON object.
+func (cs *CommandServer) LoadConfig(jsonData map[string]interface{}) error {
+	err := mergeJSONToStruct(cs.config, jsonData)
+	if err != nil {
+		return err
+	}
+	// split the AllowedCommand string into a slice
+	cs.config.allowedCommands = strings.Split(cs.config.AllowedCommand, ",")
+	return cs.config.Check()
+}
+
 func init() {
-	RegisterServ(NewCommandServer)
+	RegisterServ(CommandServerName, NewCommandServer)
 }

--- a/services/command_config.go
+++ b/services/command_config.go
@@ -22,8 +22,8 @@ import (
 
 // CommandConfig represents the configuration for allowed commands.
 type CommandConfig struct {
-	// AllowedCommands is a list of allowed commands.
-	AllowedCommands []string `json:"allowed_commands"`
+	AllowedCommand  string `json:"allowed_command"` // AllowedCommand is a list of allowed command. split by comma. e.g. ls,cat,echo
+	allowedCommands []string
 }
 
 var (
@@ -39,22 +39,19 @@ var (
 )
 
 // NewCommandConfig creates a new CommandConfig with the given allowed commands.
-func NewCommandConfig(commands []string) *CommandConfig {
-	if len(commands) == 0 {
-		commands = allowedCmdDefault
-	}
+func NewCommandConfig() *CommandConfig {
 	return &CommandConfig{
-		AllowedCommands: commands,
+		allowedCommands: allowedCmdDefault,
 	}
 }
 
 // Check validates the allowed commands in the CommandConfig.
 func (cc *CommandConfig) Check() error {
 	var cnt int
-	cnt = len(cc.AllowedCommands)
+	cnt = len(cc.allowedCommands)
 
 	// Check if any command is empty
-	for _, cmd := range cc.AllowedCommands {
+	for _, cmd := range cc.allowedCommands {
 		if cmd == "" {
 			cnt -= 1
 		}

--- a/services/config.go
+++ b/services/config.go
@@ -16,7 +16,11 @@
 
 package services
 
-import "github.com/rs/zerolog"
+import (
+	"fmt"
+	"github.com/rs/zerolog"
+	"reflect"
+)
 
 // Config is an interface that defines a method for checking configuration validity.
 type Config interface {
@@ -48,4 +52,36 @@ func (cfg *MoLingConfig) Logger() zerolog.Logger {
 
 func (cfg *MoLingConfig) SetLogger(logger zerolog.Logger) {
 	cfg.logger = logger
+}
+
+// mergeJSONToStruct 将JSON中的字段合并到结构体中
+
+func mergeJSONToStruct(target interface{}, jsonMap map[string]interface{}) error {
+	// 获取目标结构体的反射值
+	val := reflect.ValueOf(target).Elem()
+	typ := val.Type()
+
+	// 遍历JSON map中的每个字段
+	for jsonKey, jsonValue := range jsonMap {
+		// 遍历结构体的每个字段
+		for i := 0; i < typ.NumField(); i++ {
+			field := typ.Field(i)
+			// 检查JSON字段名是否与结构体的JSON tag匹配
+			if field.Tag.Get("json") == jsonKey {
+				// 获取结构体字段的反射值
+				fieldVal := val.Field(i)
+				// 检查字段是否可设置
+				if fieldVal.CanSet() {
+					// 将JSON值转换为结构体字段的类型
+					jsonVal := reflect.ValueOf(jsonValue)
+					if jsonVal.Type().ConvertibleTo(fieldVal.Type()) {
+						fieldVal.Set(jsonVal.Convert(fieldVal.Type()))
+					} else {
+						return fmt.Errorf("type mismatch for field %s, value:%v", jsonKey, jsonValue)
+					}
+				}
+			}
+		}
+	}
+	return nil
 }

--- a/services/config_test.go
+++ b/services/config_test.go
@@ -1,0 +1,61 @@
+/*
+ *
+ *  Copyright 2025 CFC4N <cfc4n.cs@gmail.com>. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  Repository: https://github.com/gojue/moling
+ *
+ */
+
+package services
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+)
+
+// TestConfigLoad tests the loading of the configuration from a JSON file.
+func TestConfigLoad(t *testing.T) {
+	configFile := "config_test.json"
+	cfg := &MoLingConfig{}
+	cfg.ConfigFile = "config.json"
+	cfg.BasePath = "/tmp/moling"
+	cfg.Version = "1.0.0"
+	cfg.ListenAddr = ":8080"
+	cfg.Debug = true
+	cfg.Username = "user1"
+	cfg.HomeDir = "/Users/user1"
+	cfg.SystemInfo = "Darwin 15.3.3"
+
+	jsonData, err := os.ReadFile(configFile)
+	if err != nil {
+		t.Fatalf("failed to read config file: %v", err)
+	}
+	var jsonMap map[string]interface{}
+	if err := json.Unmarshal(jsonData, &jsonMap); err != nil {
+		t.Fatalf("Failed to unmarshal JSON: %v", err)
+	}
+	mlConfig, ok := jsonMap["MoLingConfig"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("failed to parse MoLingConfig from JSON")
+	}
+	if err := mergeJSONToStruct(cfg, mlConfig); err != nil {
+		t.Fatalf("failed to merge JSON to struct: %v", err)
+	}
+	t.Logf("Config loaded, MoLing Config.BasePath: %s", cfg.BasePath)
+	if cfg.BasePath != "/newpath/.moling" {
+		t.Fatalf("expected BasePath to be '/newpath/.moling', got '%s'", cfg.BasePath)
+	}
+}

--- a/services/config_test.json
+++ b/services/config_test.json
@@ -1,0 +1,28 @@
+{
+  "BrowserServer": {
+  },
+  "CommandServer": {
+    "allowed_commands": [
+      "ls",
+      "cat",
+      "echo"
+    ]
+  },
+  "FilesystemServer": {
+    "allowed_dirs": [
+      "/tmp/.moling/data/"
+    ],
+    "cache_path": "/tmp/.moling/data"
+  },
+  "MoLingConfig": {
+    "HomeDir": "",
+    "SystemInfo": "",
+    "Username": "",
+    "base_path": "/newpath/.moling",
+    "config_file": "config/config.json",
+    "debug": false,
+    "listen_addr": "",
+    "version": "darwin-arm64-20250330084836-0077553"
+  },
+  "MoaServer": {}
+}

--- a/services/file_system.go
+++ b/services/file_system.go
@@ -37,6 +37,9 @@ const (
 	// MaxBase64Size Maximum size for base64 encoding (1MB)
 	MaxBase64Size = 1024 * 1024 * 1
 )
+const (
+	FilesystemServerName = "FilesystemServer"
+)
 
 type FileInfo struct {
 	Size        int64     `json:"size"`
@@ -53,17 +56,13 @@ type FilesystemServer struct {
 	config *FileSystemConfig
 }
 
-func NewFilesystemServer(ctx context.Context, args []string) (Service, error) {
+func NewFilesystemServer(ctx context.Context) (Service, error) {
 	// Validate the config
 	var err error
 	globalConf := ctx.Value(MoLingConfigKey).(*MoLingConfig)
 	userDataDir := filepath.Join(globalConf.BasePath, "data")
 
-	fc := NewFileSystemConfig([]string{userDataDir})
-
-	if err = fc.Check(); err != nil {
-		return nil, fmt.Errorf("FilesystemServer: invalid config: %v", err)
-	}
+	fc := NewFileSystemConfig(userDataDir)
 
 	lger, ok := ctx.Value(MoLingLoggerKey).(zerolog.Logger)
 	if !ok {
@@ -71,20 +70,30 @@ func NewFilesystemServer(ctx context.Context, args []string) (Service, error) {
 	}
 
 	loggerNameHook := zerolog.HookFunc(func(e *zerolog.Event, level zerolog.Level, msg string) {
-		e.Str("Service", "FileSystemServer")
+		e.Str("Service", FilesystemServerName)
 	})
 
 	fs := &FilesystemServer{
-		MLService: MLService{
-			ctx:    ctx,
-			logger: lger.Hook(loggerNameHook),
-		},
-		config: fc,
+		MLService: NewMLService(ctx, lger.Hook(loggerNameHook), globalConf),
+		config:    fc,
 	}
+
 	err = fs.init()
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize filesystem server: %v", err)
 	}
+
+	return fs, nil
+}
+
+func (fs *FilesystemServer) Init() error {
+
+	// TODO
+	//err = fs.LoadConfig(fs.config, cfg)
+	//if err != nil {
+	//	return nil, err
+	//}
+
 	// Register resource handlers
 	fs.AddResource(mcp.NewResource("file://", "File System",
 		mcp.WithResourceDescription("Access to files and directories on the local file system"),
@@ -169,8 +178,7 @@ func NewFilesystemServer(ctx context.Context, args []string) (Service, error) {
 		"list_allowed_directories",
 		mcp.WithDescription("Returns the list of directories that this server is allowed to access."),
 	), fs.handleListAllowedDirectories)
-
-	return fs, nil
+	return nil
 }
 
 // isPathInAllowedDirs checks if a path is within any of the allowed directories
@@ -193,7 +201,7 @@ func (fss *FilesystemServer) isPathInAllowedDirs(path string) bool {
 	}
 
 	// Check if the path is within any of the allowed directories
-	for _, dir := range fss.config.AllowedDirs {
+	for _, dir := range fss.config.allowedDirs {
 		if strings.HasPrefix(absPath, dir) {
 			return true
 		}
@@ -939,13 +947,10 @@ func (fss *FilesystemServer) handleGetFileInfo(ctx context.Context, request mcp.
 	}, nil
 }
 
-func (fss *FilesystemServer) handleListAllowedDirectories(
-	ctx context.Context,
-	request mcp.CallToolRequest,
-) (*mcp.CallToolResult, error) {
+func (fss *FilesystemServer) handleListAllowedDirectories(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	// Remove the trailing separator for display purposes
-	displayDirs := make([]string, len(fss.config.AllowedDirs))
-	for i, dir := range fss.config.AllowedDirs {
+	displayDirs := make([]string, len(fss.config.allowedDirs))
+	for i, dir := range fss.config.allowedDirs {
 		displayDirs[i] = strings.TrimSuffix(dir, string(filepath.Separator))
 	}
 
@@ -962,6 +967,7 @@ func (fss *FilesystemServer) handleListAllowedDirectories(
 
 // Config returns the configuration of the service as a string.
 func (fss *FilesystemServer) Config() string {
+	fss.config.AllowedDir = strings.Join(fss.config.allowedDirs, ",")
 	cfg, err := json.Marshal(fss.config)
 	if err != nil {
 		fss.logger.Err(err).Msg("failed to marshal config")
@@ -971,7 +977,7 @@ func (fss *FilesystemServer) Config() string {
 }
 
 func (fss *FilesystemServer) Name() string {
-	return "FilesystemServer"
+	return FilesystemServerName
 }
 
 func (fss *FilesystemServer) Close() error {
@@ -980,6 +986,16 @@ func (fss *FilesystemServer) Close() error {
 	return nil
 }
 
+// LoadConfig loads the configuration from a JSON object.
+func (fss *FilesystemServer) LoadConfig(jsonData map[string]interface{}) error {
+	err := mergeJSONToStruct(fss.config, jsonData)
+	if err != nil {
+		return err
+	}
+	fss.config.allowedDirs = strings.Split(fss.config.AllowedDir, ",")
+	return fss.config.Check()
+}
+
 func init() {
-	RegisterServ(NewFilesystemServer)
+	RegisterServ(FilesystemServerName, NewFilesystemServer)
 }

--- a/services/file_system.go
+++ b/services/file_system.go
@@ -87,13 +87,6 @@ func NewFilesystemServer(ctx context.Context) (Service, error) {
 }
 
 func (fs *FilesystemServer) Init() error {
-
-	// TODO
-	//err = fs.LoadConfig(fs.config, cfg)
-	//if err != nil {
-	//	return nil, err
-	//}
-
 	// Register resource handlers
 	fs.AddResource(mcp.NewResource("file://", "File System",
 		mcp.WithResourceDescription("Access to files and directories on the local file system"),

--- a/services/file_system_config.go
+++ b/services/file_system_config.go
@@ -20,37 +20,39 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 var (
-	// TODO : read from config file
-	allowedDirsDefault = []string{
-		os.TempDir(),
-	}
+	allowedDirsDefault = os.TempDir()
 )
 
 // FileSystemConfig represents the configuration for the file system.
 type FileSystemConfig struct {
-	AllowedDirs []string `json:"allowed_dirs"` // AllowedDirs is a list of allowed directories.
-	CachePath   string   `json:"cache_path"`   // CachePath is the root path for the file system.
+	AllowedDir  string `json:"allowed_dirs"` // AllowedDirs is a list of allowed directories. split by comma. e.g. /tmp,/var/tmp
+	allowedDirs []string
+	CachePath   string `json:"cache_path"` // CachePath is the root path for the file system.
 }
 
 // NewFileSystemConfig creates a new FileSystemConfig with the given allowed directories.
-func NewFileSystemConfig(path []string) *FileSystemConfig {
-	if len(path) == 0 {
+func NewFileSystemConfig(path string) *FileSystemConfig {
+	paths := strings.Split(path, ",")
+	path = ""
+	if len(paths) == 0 {
 		path = allowedDirsDefault
 	}
 
 	return &FileSystemConfig{
-		AllowedDirs: path,
-		CachePath:   path[0],
+		AllowedDir:  path,
+		CachePath:   path,
+		allowedDirs: paths,
 	}
 }
 
 // Check validates the allowed directories in the FileSystemConfig.
 func (fc *FileSystemConfig) Check() error {
-	normalized := make([]string, 0, len(fc.AllowedDirs))
-	for _, dir := range fc.AllowedDirs {
+	normalized := make([]string, 0, len(fc.allowedDirs))
+	for _, dir := range fc.allowedDirs {
 		abs, err := filepath.Abs(dir)
 		if err != nil {
 			return fmt.Errorf("failed to resolve path %s: %w", dir, err)
@@ -66,6 +68,6 @@ func (fc *FileSystemConfig) Check() error {
 
 		normalized = append(normalized, filepath.Clean(abs)+string(filepath.Separator))
 	}
-	fc.AllowedDirs = normalized
+	fc.allowedDirs = normalized
 	return nil
 }

--- a/services/file_system_config.go
+++ b/services/file_system_config.go
@@ -40,6 +40,7 @@ func NewFileSystemConfig(path string) *FileSystemConfig {
 	path = ""
 	if strings.TrimSpace(path) == "" {
 		path = allowedDirsDefault
+		paths = []string{allowedDirsDefault}
 	}
 
 	return &FileSystemConfig{

--- a/services/file_system_config.go
+++ b/services/file_system_config.go
@@ -38,7 +38,7 @@ type FileSystemConfig struct {
 func NewFileSystemConfig(path string) *FileSystemConfig {
 	paths := strings.Split(path, ",")
 	path = ""
-	if len(paths) == 0 {
+	if strings.TrimSpace(path) == "" {
 		path = allowedDirsDefault
 	}
 

--- a/services/register.go
+++ b/services/register.go
@@ -20,14 +20,15 @@ import (
 	"context"
 )
 
-var serviceLists []func(ctx context.Context, args []string) (Service, error)
+var serviceLists = make(map[string]func(ctx context.Context) (Service, error))
 
 // RegisterServ register service
-func RegisterServ(f func(ctx context.Context, args []string) (Service, error)) {
-	serviceLists = append(serviceLists, f)
+func RegisterServ(n string, f func(ctx context.Context) (Service, error)) {
+	//serviceLists = append(, f)
+	serviceLists[n] = f
 }
 
 // ServiceList  get service lists
-func ServiceList() []func(ctx context.Context, args []string) (Service, error) {
+func ServiceList() map[string]func(ctx context.Context) (Service, error) {
 	return serviceLists
 }

--- a/services/service.go
+++ b/services/service.go
@@ -48,6 +48,11 @@ type Service interface {
 
 	// Config returns the configuration of the service as a string.
 	Config() string
+	// LoadConfig loads the configuration for the service from a map.
+	LoadConfig(jsonData map[string]interface{}) error
+
+	// Init initializes the service with the given context and configuration.
+	Init() error
 
 	MlConfig() *MoLingConfig
 
@@ -70,6 +75,15 @@ func (pe *PromptEntry) Prompt() mcp.Prompt {
 func (pe *PromptEntry) Handler() server.PromptHandlerFunc {
 	return pe.phf
 
+}
+
+// NewMLService creates a new MLService with the given context and logger.
+func NewMLService(ctx context.Context, logger zerolog.Logger, cfg *MoLingConfig) MLService {
+	return MLService{
+		ctx:      ctx,
+		logger:   logger,
+		mlConfig: cfg,
+	}
 }
 
 // MLService implements the Service interface and provides methods to manage resources, templates, prompts, tools, and notification handlers.
@@ -194,6 +208,7 @@ func (mls *MLService) callToolResult(isError bool, msg string) *mcp.CallToolResu
 	}
 }
 
+// MlConfig returns the configuration of the MoLing service.
 func (mls *MLService) MlConfig() *MoLingConfig {
 	return mls.mlConfig
 }
@@ -203,6 +218,17 @@ func (mls *MLService) Config() string {
 	panic("not implemented yet") // TODO: Implement
 }
 
+// Name returns the name of the service.
 func (mls *MLService) Name() string {
 	panic("not implemented yet") // TODO: Implement
+}
+
+// LoadConfig loads the configuration for the service from a map.
+func (mls *MLService) LoadConfig(jsonData map[string]interface{}) error {
+	//panic("not implemented yet") // TODO: Implement
+	err := mergeJSONToStruct(mls.mlConfig, jsonData)
+	if err != nil {
+		return err
+	}
+	return mls.mlConfig.Check()
 }

--- a/services/utils.go
+++ b/services/utils.go
@@ -73,3 +73,19 @@ func isImageFile(mimeType string) bool {
 func pathToResourceURI(path string) string {
 	return "file://" + path
 }
+
+// CreateDirectory checks if a directory exists, and creates it if it doesn't
+func CreateDirectory(path string) error {
+	_, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			err = os.MkdirAll(path, 0o755)
+			if err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
This pull request includes several significant changes to the `cli` and `services` packages to enhance configuration handling, improve initialization processes, and standardize service implementations. The most important changes are summarized below:

### Configuration Handling Improvements:
* [`cli/cmd/config.go`](diffhunk://#diff-7e99687b5d846708c7b5a928628f9646f5c6f4bd52c231a75a46b78b09ca57adR56-R71): Added checks for existing configuration files and logic to load and merge configurations from JSON. [[1]](diffhunk://#diff-7e99687b5d846708c7b5a928628f9646f5c6f4bd52c231a75a46b78b09ca57adR56-R71) [[2]](diffhunk://#diff-7e99687b5d846708c7b5a928628f9646f5c6f4bd52c231a75a46b78b09ca57adL66-R102)
* [`services/config.go`](diffhunk://#diff-6edc66a61226196eb1a3035bd1dad77b4c22d2cab11dc33ae62c9cfa4c71a8e9R56-R87): Introduced `mergeJSONToStruct` function to merge JSON fields into struct fields.

### Service Initialization Enhancements:
* [`services/browser.go`](diffhunk://#diff-d28c280801f4a5ac525d036ee232b3823a6bdf7c800c3127cea2a2c1ef8e9d37L43-L94): Modified `NewBrowserServer` to remove the `args` parameter and added an `Init` method to handle initialization logic. [[1]](diffhunk://#diff-d28c280801f4a5ac525d036ee232b3823a6bdf7c800c3127cea2a2c1ef8e9d37L43-L94) [[2]](diffhunk://#diff-d28c280801f4a5ac525d036ee232b3823a6bdf7c800c3127cea2a2c1ef8e9d37L168-R177)
* [`services/command.go`](diffhunk://#diff-255513b4527fd7bbbf2e847c570842c03e574d5974694b8ee056e8bc44a3def3L46-R52): Updated `NewCommandServer` to remove the `args` parameter and added an `Init` method for initialization. [[1]](diffhunk://#diff-255513b4527fd7bbbf2e847c570842c03e574d5974694b8ee056e8bc44a3def3L46-R52) [[2]](diffhunk://#diff-255513b4527fd7bbbf2e847c570842c03e574d5974694b8ee056e8bc44a3def3R77-R86)

### Test Adjustments:
* [`cli/cmd/moling_test.go`](diffhunk://#diff-5756556199475fd92f37a545bc5a77e7a8aac2fe0e62333c0a3970235853ef57L41-R48): Updated the test for `NewMLServer` to call the `Init` method on the filesystem server.
* [`services/browser_test.go`](diffhunk://#diff-8eb8f1614e57f87ed7697dc0d76e41ccdb1e8407c2416862af94dfebd538283bL62-R63): Adjusted the test for `NewBrowserServer` to match the new function signature.

### JSON Handling and Logging:
* [`cli/cmd/root.go`](diffhunk://#diff-eb154bbd601602eeae895e7af6a12b88cbdb7d585a2d32216c398f68cabcdff5R154-R189): Added JSON handling for the configuration file in the `mlsCommandFunc` function.
* [`services/browser.go`](diffhunk://#diff-d28c280801f4a5ac525d036ee232b3823a6bdf7c800c3127cea2a2c1ef8e9d37L331-R363): Standardized logging to use service names defined as constants.

### Miscellaneous Changes:
* [`services/command_config.go`](diffhunk://#diff-57d7ce15f7c1f27dddc6ea04860cf324dd5bbaf0b4663744d583bc4acb26c03dL25-R26): Changed the `CommandConfig` structure to use a single string for allowed commands, split by commas. [[1]](diffhunk://#diff-57d7ce15f7c1f27dddc6ea04860cf324dd5bbaf0b4663744d583bc4acb26c03dL25-R26) [[2]](diffhunk://#diff-57d7ce15f7c1f27dddc6ea04860cf324dd5bbaf0b4663744d583bc4acb26c03dL42-R54)

These changes collectively improve the robustness and maintainability of the codebase by enhancing configuration management, standardizing service initialization, and improving logging practices.