### PR TITLE
feat: add logging enhancements and listen address flag for SSE mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ include variables.mk
 include functions.mk
 
 .PHONY: all | env
-all: clean test build
+all: clean test format build
 	@echo $(shell date)
 
 .ONESHELL:
@@ -59,7 +59,8 @@ build:clean
 .PHONY: format
 format:
 	@echo "  ->  Formatting code"
-	golangci-lint run  --disable-all -E errcheck -E staticcheck
+	golangci-lint run --disable-all -E errcheck -E staticcheck
+
 .PHONY: test
 test:
 	CGO_ENABLED=1 go test -v -race ./...

--- a/cli/cmd/moling.go
+++ b/cli/cmd/moling.go
@@ -97,7 +97,7 @@ func (m *MoLingServer) loadService(srv services.Service) error {
 func (s *MoLingServer) Serve() error {
 	mLogger := log.New(s.logger, MCPServerName, 0)
 	if s.listenAddr != "" {
-		ltnAddr := fmt.Sprintf("http://%s", strings.Trim(s.listenAddr, "http://"))
+		ltnAddr := fmt.Sprintf("http://%s", strings.TrimPrefix(s.listenAddr, "http://"))
 		consoleWriter := zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: time.RFC3339}
 		multi := zerolog.MultiLevelWriter(consoleWriter, s.logger)
 		s.logger = zerolog.New(multi).With().Timestamp().Logger()

--- a/cli/cmd/moling.go
+++ b/cli/cmd/moling.go
@@ -16,10 +16,14 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 	"github.com/gojue/moling/services"
 	"github.com/mark3labs/mcp-go/server"
 	"github.com/rs/zerolog"
 	"log"
+	"os"
+	"strings"
+	"time"
 )
 
 type MoLingServer struct {
@@ -91,10 +95,16 @@ func (m *MoLingServer) loadService(srv services.Service) error {
 }
 
 func (s *MoLingServer) Serve() error {
-	mLogger := log.New(s.logger, "MoLingServer", 0)
+	mLogger := log.New(s.logger, MCPServerName, 0)
 	if s.listenAddr != "" {
-		return server.NewSSEServer(s.server, server.WithBaseURL(s.listenAddr),
-			server.WithBasePath("/mcp")).Start(s.listenAddr)
+		ltnAddr := fmt.Sprintf("http://%s", strings.Trim(s.listenAddr, "http://"))
+		consoleWriter := zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: time.RFC3339}
+		multi := zerolog.MultiLevelWriter(consoleWriter, s.logger)
+		s.logger = zerolog.New(multi).With().Timestamp().Logger()
+		s.logger.Info().Str("listenAddr", s.listenAddr).Str("BaseURL", ltnAddr).Msg("Starting SSE server")
+		s.logger.Warn().Msgf("The SSE server URL must be: %s. Please do not make mistakes, even if it is another IP or domain name on the same computer, it cannot be mixed.", ltnAddr)
+		return server.NewSSEServer(s.server, server.WithBaseURL(ltnAddr)).Start(s.listenAddr)
 	}
+	s.logger.Info().Msg("Starting STDIO server")
 	return server.ServeStdio(s.server, server.WithErrorLogger(mLogger))
 }

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -126,6 +126,7 @@ func init() {
 	// when this action is called directly.
 	rootCmd.PersistentFlags().StringVar(&mlConfig.BasePath, "base_path", mlConfig.BasePath, "MoLing Base Data Path, automatically set by the system, cannot be changed, display only.")
 	rootCmd.PersistentFlags().BoolVarP(&mlConfig.Debug, "debug", "d", false, "Debug mode, default is false.")
+	rootCmd.PersistentFlags().StringVarP(&mlConfig.ListenAddr, "listen_addr", "l", "", "listen address for SSE mode. default:'', not listen, used STDIO mode.")
 	rootCmd.SilenceUsage = true
 }
 


### PR DESCRIPTION
This pull request includes several changes to the `cli/cmd` package, focusing on enhancing logging, server initialization, and command-line flag handling. The most significant changes are the addition of new imports, updates to the `Serve` method to improve logging and server setup, and the introduction of a new command-line flag for specifying the listen address.

### Improvements to logging and server setup:

* [`cli/cmd/moling.go`](diffhunk://#diff-bb6440df53bba79d771aed1062711c3be3ecf67035f12e653ca2bc4999082057R19-R26): Added new imports for `fmt`, `os`, `strings`, and `time` to support enhanced logging and server setup.
* [`cli/cmd/moling.go`](diffhunk://#diff-bb6440df53bba79d771aed1062711c3be3ecf67035f12e653ca2bc4999082057L94-R108): Updated the `Serve` method in `MoLingServer` to use `zerolog` for improved logging, including detailed startup messages and warnings about the SSE server URL.

### Command-line flag handling:

* [`cli/cmd/root.go`](diffhunk://#diff-eb154bbd601602eeae895e7af6a12b88cbdb7d585a2d32216c398f68cabcdff5R129): Added a new persistent flag `listen_addr` to specify the listen address for SSE mode, with a default value of an empty string indicating the use of STDIO mode.