### PR TITLE
feat: add client command for automated MCP Server configuration management

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ For example, to configure the Claude client, add the following configuration:
 
 and, `/usr/local/bin/moling` is the path to the MoLing server binary you downloaded.
 
+**Automatic Configuration**
+run `moling client --install` to automatically install the configuration for the MCP client.
+
+MoLing will automatically detect the MCP client and install the configuration for you. including: Cline, Claude, Roo
+Code, etc.
+
 ### Operation Modes
 
 - **Stdio Mode**: CLI-based interactive mode for user-friendly experience
@@ -92,7 +98,7 @@ and, `/usr/local/bin/moling` is the path to the MoLing server binary you downloa
 ```
 ##### Windows
 
-[!WARNING]
+> [!WARNING]
 > Not tested, unsure if it works.
 
 ```powershell

--- a/README_ZH_HANS.md
+++ b/README_ZH_HANS.md
@@ -75,6 +75,9 @@ MoLing是一个computer-use和browser-use的MCP Server，基于操作系统API�
 
 另外， `/usr/local/bin/moling` 是你存放`MoLing` Server可执行文件的路径，可以自己指定。
 
+**自动配置**
+运行 `moling client --install` 命令将会自动为本机的所有MCP客户端安装MoLing。包括Cline、 Claude、 Roo Code等等。
+
 ### 运行模式
 
 - **Stdio模式**：本地命令行交互模式，依赖于终端输入输出，适合人机交互
@@ -91,7 +94,7 @@ MoLing是一个computer-use和browser-use的MCP Server，基于操作系统API�
 
 ##### Windows
 
-[!WARNING]
+> [!WARNING]
 > 未测试，不确定是否正常。
 
 ```powershell

--- a/cli/cmd/client.go
+++ b/cli/cmd/client.go
@@ -1,0 +1,78 @@
+/*
+ *
+ *  Copyright 2025 CFC4N <cfc4n.cs@gmail.com>. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  Repository: https://github.com/gojue/moling
+ *
+ */
+
+package cmd
+
+import (
+	"github.com/gojue/moling/client"
+	"github.com/rs/zerolog"
+	"github.com/spf13/cobra"
+	"os"
+	"time"
+)
+
+var clientCmd = &cobra.Command{
+	Use:   "client",
+	Short: "Provides automated access to MoLing MCP Server for local MCP clients, Cline, Roo Code, and Claude, etc.",
+	Long: `Automatically checks the MCP clients installed on the current computer, displays them, and automatically adds the MoLing MCP Server configuration to enable one-click activation, reducing the hassle of manual configuration.
+Currently supports the following clients: Cline, Roo Code, Claude
+    moling client -l --list   List the current installed MCP clients
+    moling client -i --install Add MoLing MCP Server configuration to the currently installed MCP clients on this computer
+`,
+	RunE: ClientCommandFunc,
+}
+
+var (
+	list    bool
+	install bool
+)
+
+// ClientCommandFunc executes the "config" command.
+func ClientCommandFunc(command *cobra.Command, args []string) error {
+	logger := initLogger(mlConfig.BasePath)
+	consoleWriter := zerolog.ConsoleWriter{Out: os.Stdout, TimeFormat: time.RFC3339}
+	multi := zerolog.MultiLevelWriter(consoleWriter, logger)
+	logger = zerolog.New(multi).With().Timestamp().Logger()
+	mlConfig.SetLogger(logger)
+	logger.Info().Msg("Start to show MCP Clients")
+	mcpConfig := client.NewMCPServerConfig(CliDescription, CliName, MCPServerName)
+	exePath, err := os.Executable()
+	if err == nil {
+		logger.Info().Str("exePath", exePath).Msg("executable path, will use this path to find the config file")
+		mcpConfig.Command = exePath
+	}
+	cm := client.NewManager(logger, mcpConfig)
+	if install {
+		logger.Info().Msg("Start to add MCP Server configuration into MCP Clients.")
+		cm.SetupConfig()
+		logger.Info().Msg("Add MCP Server configuration into MCP Clients successfully.")
+		return nil
+	}
+	logger.Info().Msg("Start to list MCP Clients")
+	cm.ListClient()
+	logger.Info().Msg("List MCP Clients successfully.")
+	return nil
+}
+
+func init() {
+	clientCmd.PersistentFlags().BoolVar(&list, "list", false, "List the current installed MCP clients")
+	clientCmd.PersistentFlags().BoolVarP(&install, "install", "i", false, "Add MoLing MCP Server configuration to the currently installed MCP clients on this computer. default is all")
+	rootCmd.AddCommand(clientCmd)
+}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -34,8 +34,8 @@ import (
 const (
 	CliName            = "moling"
 	CliNameZh          = "魔灵"
-	MCPServerName      = "Gojue MoLing Server"
-	CliDescription     = "A local office automation magic assistant, Moling can help you perform file viewing, reading, and other related tasks, as well as assist with command-line operations."
+	MCPServerName      = "MoLing MCP Server"
+	CliDescription     = "A local office automation magic assistant, MoLing can help you perform file viewing, reading, and other related tasks, as well as assist with command-line operations."
 	CliDescriptionZh   = "本地办公自动化魔法助手，可以帮你实现文件查看、阅读等操作，也可以帮你执行命令行操作。"
 	CliHomepage        = "https://gojue.cc/moling"
 	CliAuthor          = "CFC4N <cfc4ncs@gmail.com>"
@@ -43,25 +43,29 @@ const (
 	CliDescriptionLong = `
 MoLing is a computer-based MCP Server that implements system interaction through operating system APIs, enabling file system operations such as reading, writing, merging, statistics, and aggregation, as well as the ability to execute system commands. It is a dependency-free local office automation assistant.
 
-Requiring no installation of any dependencies, Moling can be run directly and is compatible with multiple operating systems, including Windows, Linux, and macOS. This eliminates the hassle of dealing with environment conflicts involving Node.js, Python, and other development environments.
+Requiring no installation of any dependencies, MoLing can be run directly and is compatible with multiple operating systems, including Windows, Linux, and macOS. This eliminates the hassle of dealing with environment conflicts involving Node.js, Python, and other development environments.
 
 Usage:
   moling config
-  moling -l 127.0.0:8080
+  moling -l 127.0.0.1:8080
+  moling client --install
   moling -h
 `
-	CliDescriptionLongZh = `Moling（魔灵） 是一个computer-use的MCP Server，基于操作系统API实现了系统交互，可以实现文件系统的读写、合并、统计、聚合等操作，也可以执行系统命令操作。是一个无需任何依赖的本地办公自动化助手。
+	CliDescriptionLongZh = `MoLing（魔灵） 是一个computer-use的MCP Server，基于操作系统API实现了系统交互，可以实现文件系统的读写、合并、统计、聚合等操作，也可以执行系统命令操作。是一个无需任何依赖的本地办公自动化助手。
 没有任何安装依赖，直接运行，兼容Windows、Linux、macOS等操作系统。再也不用苦恼NodeJS、Python等环境冲突等问题。
 
 Usage:
-  moling config
-  moling -l 127.0.0:8080
+  moling
+  moling -l 127.0.0.1:6789
   moling -h
+  moling client -i
+  moling config 
 `
 )
 
 const (
 	MLConfigName = "config.json" // config file name of MoLing Server
+	MLROOTPATH   = ".moling"     // config file name of MoLing Server
 )
 
 var (
@@ -69,7 +73,7 @@ var (
 	mlConfig   = &services.MoLingConfig{
 		Version:    GitVersion,
 		ConfigFile: filepath.Join("config", MLConfigName),
-		BasePath:   filepath.Join(os.TempDir(), ".moling"), // will set in mlsCommandPreFunc
+		BasePath:   filepath.Join(os.TempDir(), MLROOTPATH), // will set in mlsCommandPreFunc
 	}
 
 	// mlDirectories is a list of directories to be created in the base path

--- a/client/client.go
+++ b/client/client.go
@@ -1,0 +1,157 @@
+/*
+ *
+ *  Copyright 2025 CFC4N <cfc4n.cs@gmail.com>. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  Repository: https://github.com/gojue/moling
+ *
+ */
+
+package client
+
+import (
+	"encoding/json"
+	"errors"
+	"github.com/rs/zerolog"
+	"os"
+)
+
+var (
+	// ClineConfigPath is the path to the Cline config file.
+	clientLists = make(map[string]string, 3)
+)
+
+const MCPServersKey = "mcpServers"
+
+// MCPServerConfig represents the configuration for the MCP Client.
+type MCPServerConfig struct {
+	Description string   `json:"description"`       // Description of the MCP Server
+	IsActive    bool     `json:"isActive"`          // Is the MCP Server active
+	Command     string   `json:"command,omitempty"` // Command to start the MCP Server, STDIO mode only
+	Args        []string `json:"args,omitempty"`    // Arguments to pass to the command, STDIO mode only
+	BaseUrl     string   `json:"baseUrl,omitempty"` // Base URL of the MCP Server, SSE mode only
+	TimeOut     uint16   `json:"timeout,omitempty"` // Timeout for the MCP Server, default is 300 seconds
+	ServerName  string
+}
+
+// NewMCPServerConfig creates a new MCPServerConfig instance.
+func NewMCPServerConfig(description string, command string, srvName string) MCPServerConfig {
+	return MCPServerConfig{
+		Description: description,
+		IsActive:    true,
+		Command:     command,
+		Args:        []string{}, // not used
+		BaseUrl:     "",
+		ServerName:  srvName,
+		TimeOut:     300,
+	}
+}
+
+// Manager manages the configuration of different clients.
+type Manager struct {
+	logger    zerolog.Logger
+	clients   map[string]string
+	mcpConfig MCPServerConfig
+}
+
+// NewManager creates a new ClientManager instance.
+func NewManager(lger zerolog.Logger, mcpConfig MCPServerConfig) (cm *Manager) {
+	cm = &Manager{
+		clients:   make(map[string]string, 3),
+		logger:    lger,
+		mcpConfig: mcpConfig,
+	}
+	cm.clients = clientLists // TODO 参数化
+	return cm
+}
+
+// ListClient lists all the clients and checks if they exist.
+func (c *Manager) ListClient() {
+	for name, path := range c.clients {
+		c.logger.Debug().Msgf("Client %s: %s", name, path)
+		if !c.checkExist(path) {
+			// path not exists
+			c.logger.Info().Str("Client Name", name).Bool("exist", false).Msg("Client is not exist")
+		} else {
+			c.logger.Info().Str("Client Name", name).Bool("exist", true).Msg("Client is exist")
+		}
+	}
+	return
+}
+
+// SetupConfig sets up the configuration for the clients.
+func (c *Manager) SetupConfig() {
+	for name, path := range c.clients {
+		c.logger.Info().Msgf("Client %s: %s", name, path)
+		if !c.checkExist(path) {
+			continue
+		}
+		// read config file
+		file, err := os.ReadFile(path)
+		if err != nil {
+			c.logger.Error().Str("Client Name", name).Msgf("Failed to open config file %s: %s", path, err)
+			continue
+		}
+		c.logger.Debug().Str("Client Name", name).Str("config", string(file)).Send()
+		b, err := c.appendConfig(c.mcpConfig.ServerName, file)
+		if err != nil {
+			c.logger.Error().Str("Client Name", name).Msgf("Failed to append config file %s: %s", path, err)
+			continue
+		}
+		c.logger.Debug().Str("Client Name", name).Str("newConfig", string(b)).Send()
+		// write config file
+		err = os.WriteFile(path, b, 0644)
+		if err != nil {
+			c.logger.Error().Str("Client Name", name).Msgf("Failed to write config file %s: %s", path, err)
+			continue
+		}
+	}
+	return
+}
+
+// appendConfig appends the mlMCPConfig to the client config.
+func (c *Manager) appendConfig(name string, payload []byte) ([]byte, error) {
+	var err error
+	var jsonMap map[string]interface{}
+	var jsonBytes []byte
+	err = json.Unmarshal(payload, &jsonMap)
+	if err != nil {
+		return nil, err
+	}
+	jsonMcpServer, ok := jsonMap[MCPServersKey].(map[string]interface{})
+	if !ok {
+		return nil, errors.New("MCPServersKey not found in JSON")
+	}
+	jsonMcpServer[name] = c.mcpConfig
+	jsonMap[MCPServersKey] = jsonMcpServer
+	jsonBytes, err = json.MarshalIndent(jsonMap, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return jsonBytes, nil
+}
+
+// checkExist checks if the file at the given path exists.
+func (c *Manager) checkExist(path string) bool {
+	_, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			c.logger.Debug().Msgf("Client config file %s does not exist", path)
+			return false
+		}
+		c.logger.Info().Msgf("check file failed, error:%v", err)
+		return false
+	}
+	return true
+}

--- a/client/client_config.go
+++ b/client/client_config.go
@@ -1,0 +1,34 @@
+//go:build !windows
+
+/*
+ *
+ *  Copyright 2025 CFC4N <cfc4n.cs@gmail.com>. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  Repository: https://github.com/gojue/moling
+ *
+ */
+
+package client
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func init() {
+	clientLists["Cline"] = filepath.Join(os.Getenv("HOME"), "Library", "Application Support", "Code", "User", "globalStorage", "saoudrizwan.claude-dev", "settings", "cline_mcp_settings.json")
+	clientLists["Roo Code"] = filepath.Join(os.Getenv("HOME"), "Library", "Application Support", "Code", "User", "globalStorage", "rooveterinaryinc.roo-cline", "settings", "mcp_settings.json")
+	clientLists["Claude"] = filepath.Join(os.Getenv("HOME"), "Library", "Application Support", "Claude", "claude_desktop_config.json")
+}

--- a/client/client_config_windows.go
+++ b/client/client_config_windows.go
@@ -20,7 +20,10 @@
 
 package client
 
-import "path/filepath"
+import (
+	"os"
+	"path/filepath"
+)
 
 func init() {
 	clientLists["Cline"] = filepath.Join(os.Getenv("APPDATA"), "Code", "User", "globalStorage", "saoudrizwan.claude-dev", "settings", "cline_mcp_settings.json")

--- a/client/client_config_windows.go
+++ b/client/client_config_windows.go
@@ -1,0 +1,29 @@
+/*
+ *
+ *  Copyright 2025 CFC4N <cfc4n.cs@gmail.com>. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  Repository: https://github.com/gojue/moling
+ *
+ */
+
+package client
+
+import "path/filepath"
+
+func init() {
+	clientLists["Cline"] = filepath.Join(os.Getenv("APPDATA"), "Code", "User", "globalStorage", "saoudrizwan.claude-dev", "settings", "cline_mcp_settings.json")
+	clientLists["Roo Code"] = filepath.Join(os.Getenv("APPDATA"), "Code", "User", "globalStorage", "rooveterinaryinc.roo-cline", "settings", "mcp_settings.json")
+	clientLists["Claude"] = filepath.Join(os.Getenv("APPDATA"), "Claude", "claude_desktop_config.json")
+}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,0 +1,117 @@
+/*
+ *
+ *  Copyright 2025 CFC4N <cfc4n.cs@gmail.com>. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  Repository: https://github.com/gojue/moling
+ *
+ */
+
+package client
+
+import (
+	"github.com/rs/zerolog"
+	"os"
+	"testing"
+)
+
+func TestClientManager_ListClient(t *testing.T) {
+	logger := zerolog.New(os.Stdout)
+	mcpConfig := NewMCPServerConfig("MoLing UnitTest Description", "moling_test", "MoLing MCP Server")
+	cm := NewManager(logger, mcpConfig)
+	// Mock client list
+	clientLists["TestClient"] = "/path/to/nonexistent/file"
+
+	cm.ListClient()
+	// Check logs or other side effects as needed
+}
+
+/*
+	func TestClientManager_SetupConfig(t *testing.T) {
+		logger := zerolog.New(os.Stdout)
+		mcpConfig := NewMCPServerConfig("MoLing UnitTest Description", "moling_test", "MoLing MCP Server")
+		cm := NewManager(logger, mcpConfig)
+
+		// Mock client list
+		clientLists["TestClient"] = "/path/to/nonexistent/file"
+
+		cm.SetupConfig()
+		// Check logs or other side effects as needed
+	}
+
+	func TestClientManager_appendConfig(t *testing.T) {
+		logger := zerolog.New(os.Stdout)
+		mcpConfig := NewMCPServerConfig("MoLing UnitTest Description", "moling_test", "MoLing MCP Server")
+		cm := NewManager(logger, mcpConfig)
+
+		// Mock payload
+		payload := []byte(`{
+	  "Cline": {
+	    "description": "MoLing UnitTest Description",
+	    "isActive": true,
+	    "command": "moling_test"
+	  },
+	  "mcpServers": {
+	    "testABC": {
+	      "args": [
+	        "--allow-dir",
+	        "/tmp/,/Users/username/Downloads"
+	      ],
+	      "command": "npx",
+	      "timeout": 300
+	    }
+	  }
+	}`)
+
+	result, err := cm.appendConfig("TestClient", payload)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	var resultMap map[string]interface{}
+	err = json.Unmarshal(result, &resultMap)
+	if err != nil {
+		t.Fatalf("Expected valid JSON, got error %v", err)
+	}
+
+	if resultMap["existingKey"] != "existingValue" {
+		t.Errorf("Expected existingKey to be existingValue, got %v", resultMap["existingKey"])
+	}
+
+}
+*/
+
+func TestClientManager_checkExist(t *testing.T) {
+	logger := zerolog.New(os.Stdout)
+	mcpConfig := NewMCPServerConfig("MoLing UnitTest Description", "moling_test", "MoLing MCP Server")
+	cm := NewManager(logger, mcpConfig)
+
+	// Test with a non-existent file
+	exists := cm.checkExist("/path/to/nonexistent/file")
+	if exists {
+		t.Errorf("Expected file to not exist")
+	}
+
+	// Test with an existing file
+	file, err := os.CreateTemp("", "testfile")
+	if err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+	defer os.Remove(file.Name())
+	t.Logf("Created temp file: %s", file.Name())
+	exists = cm.checkExist(file.Name())
+	if !exists {
+		t.Errorf("Expected file to exist")
+	}
+}

--- a/install/install.sh
+++ b/install/install.sh
@@ -55,5 +55,8 @@ fi
 # initialize the configuration
 echo "Initializing MoLing configuration..."
 moling config --init
-
 echo "MoLing configuration initialized successfully!"
+
+echo "setup MCP Server configuration into MCP Client"
+moling client -i -d
+echo "MCP Client configuration setup successfully!"

--- a/services/config.go
+++ b/services/config.go
@@ -39,7 +39,13 @@ type MoLingConfig struct {
 	Username   string // The username of the user running the server.
 	HomeDir    string // The home directory of the user running the server. macOS: /Users/user1, Linux: /home/user1
 	SystemInfo string // The system information of the user running the server. macOS: Darwin 15.3.3, Linux: Ubuntu 20.04.1 LTS
-	logger     zerolog.Logger
+
+	// for MCP Server Config
+	Description string // Description of the MCP Server, default: CliDescription
+	Command     string //	Command to start the MCP Server, STDIO mode only,  default: CliName
+	Args        string // Arguments to pass to the command, STDIO mode only, default: empty
+	BaseUrl     string // BaseUrl , SSE mode only.
+	logger      zerolog.Logger
 }
 
 func (cfg *MoLingConfig) Check() error {


### PR DESCRIPTION
This pull request introduces several new features and improvements to the MoLing MCP Server, including automatic configuration for MCP clients, new commands, and updates to documentation. The most important changes include the addition of a new `client` command, updates to configuration files, and improvements to the README documentation.

### New Features and Commands:
* [`cli/cmd/client.go`](diffhunk://#diff-ef3eab6ea4159d0a41b5c3d9b6ede3515c32da492d79762f12d43d92569cea46R1-R78): Added a new `client` command to provide automated access to MoLing MCP Server for local MCP clients. This command can list installed MCP clients and automatically add the MoLing MCP Server configuration.
* [`client/client.go`](diffhunk://#diff-bd3a55a72186f59e2e63efb4951573b2f9e4a7cc98086e922b0859f8ccc1dd09R1-R157): Implemented the client management logic, including listing MCP clients and setting up configurations for them.
* `client/client_config.go`, `client/client_config_windows.go`: Defined the paths for MCP client configuration files for different operating systems. [[1]](diffhunk://#diff-5bb8a51ea0a9cc95b06e9b870940ebed593bd6864b5e2e77d6cec085e201de94R1-R34) [[2]](diffhunk://#diff-bb26f7c83997799f6cdde45671aede1217d622bce555e131a7ac532b79c38bbaR1-R29)

### Documentation Updates:
* `README.md`, `README_ZH_HANS.md`: Added instructions for automatic configuration of MCP clients using the new `client` command. Updated the warning note format for Windows. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R81-R86) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L95-R101) [[3]](diffhunk://#diff-6ea0f6dab2a83dfaf15ed42299bf2d9bf4c6477c4901ddd6dd0c6cee8676f0eeR78-R80) [[4]](diffhunk://#diff-6ea0f6dab2a83dfaf15ed42299bf2d9bf4c6477c4901ddd6dd0c6cee8676f0eeL94-R97)

### Configuration and Initialization:
* [`cli/cmd/root.go`](diffhunk://#diff-eb154bbd601602eeae895e7af6a12b88cbdb7d585a2d32216c398f68cabcdff5L37-R76): Updated the description and usage instructions for the MoLing MCP Server. Added the `client --install` command to the usage examples.
* [`install/install.sh`](diffhunk://#diff-65845b92f5ee07169285791a57b33dd35b5792a60a4d436d2c761324a492a2c1L58-R62): Added steps to set up MCP Server configuration into MCP Client during initialization.
* [`services/config.go`](diffhunk://#diff-6edc66a61226196eb1a3035bd1dad77b4c22d2cab11dc33ae62c9cfa4c71a8e9R42-R47): Added new fields to the `MoLingConfig` struct for MCP Server configuration.

### Licensing and Repository Information:
* Added license headers to new and existing files to ensure compliance with the Apache License, Version 2.0. [[1]](diffhunk://#diff-ef3eab6ea4159d0a41b5c3d9b6ede3515c32da492d79762f12d43d92569cea46R1-R78) [[2]](diffhunk://#diff-bd3a55a72186f59e2e63efb4951573b2f9e4a7cc98086e922b0859f8ccc1dd09R1-R157) [[3]](diffhunk://#diff-5bb8a51ea0a9cc95b06e9b870940ebed593bd6864b5e2e77d6cec085e201de94R1-R34) [[4]](diffhunk://#diff-bb26f7c83997799f6cdde45671aede1217d622bce555e131a7ac532b79c38bbaR1-R29) [[5]](diffhunk://#diff-57cdc3e29d0ef725a50897a4fbd1c4f76353429fa66d3a785dcbc17dcd7b6f31R1-R117)