### PR TITLE
Improve builder

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,8 +27,8 @@ jobs:
       - name: MoLing Build
         run: |
           make clean
-          TARGET_OS=${{ matrix.os }} TARGET_ARCH=${{ matrix.arch }} make env
-          TARGET_OS=${{ matrix.os }} TARGET_ARCH=${{ matrix.arch }} make build
+          SNAPSHOT_VERSION=${{ github.ref_name }} TARGET_OS=${{ matrix.os }} TARGET_ARCH=${{ matrix.arch }} make env
+          SNAPSHOT_VERSION=${{ github.ref_name }} TARGET_OS=${{ matrix.os }} TARGET_ARCH=${{ matrix.arch }} make build
           pwd
           ls -al ./bin
       - name: Create Archive
@@ -41,11 +41,15 @@ jobs:
           else
             tar -czvf dist/moling-${{ github.ref_name }}-${{ matrix.os }}-${{ matrix.arch }}.tar.gz -C ./bin/ .
           fi
+  upload-release-assets:
+    needs: build-on-ubuntu2204
+    runs-on: ubuntu-22.04
+    steps:
       - name: Upload Release Asset
         uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
-            tag_name: ${{ github.ref_name }}
-            generate_release_notes: true
-            files: |
-                ./dist/moling-${{ github.ref_name }}-${{ matrix.os }}-${{ matrix.arch }}.*
+          tag_name: ${{ github.ref_name }}
+          generate_release_notes: true
+          files: |
+            ./dist/moling-${{ github.ref_name }}-${{ matrix.os }}-${{ matrix.arch }}.*

--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,8 @@ SHELL = /bin/bash
 .PHONY: env
 env:
 	@echo ---------------------------------------
-	@echo "eCapture Makefile Environment:"
+	@echo "MoLing Makefile Environment:"
 	@echo ---------------------------------------
-	@echo ----------------[ from args ]---------------
 	@echo "SNAPSHOT_VERSION         $(SNAPSHOT_VERSION)"
 	@echo ---------------------------------------
 	@echo "OS_NAME                  $(OS_NAME)"
@@ -38,7 +37,7 @@ help:
 	@echo "    $$ make env					# show makefile environment/variables"
 	@echo ""
 	@echo "# build"
-	@echo "    $$ make all					# build ecapture"
+	@echo "    $$ make all					# build MoLing"
 	@echo ""
 	@echo "# clean"
 	@echo "    $$ make clean				# wipe ./bin/"

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 English | [中文](./README_ZH_HANS.md) | [日本語](./README_JA_JP.md)
 
-[![GitHub stars](https://img.shields.io/github/stars/gojue/moling.svg?label=Stars&logo=github)](https://github.com/gojue/moling)
-[![GitHub forks](https://img.shields.io/github/forks/gojue/moling?label=Forks&logo=github)](https://github.com/gojue/moling)
-[![CI](https://github.com/gojue/moling/actions/workflows/go-test.yml/badge.svg)](https://github.com/gojue/ecapture/actions/workflows/go-test.yml)
+[![GitHub stars](https://img.shields.io/github/stars/gojue/moling.svg?label=Stars&logo=github)](https://github.com/gojue/moling/stargazers)
+[![GitHub forks](https://img.shields.io/github/forks/gojue/moling?label=Forks&logo=github)](https://github.com/gojue/moling/forks)
+[![CI](https://github.com/gojue/moling/actions/workflows/go-test.yml/badge.svg)](https://github.com/gojue/moling/actions/workflows/go-test.yml)
 [![Github Version](https://img.shields.io/github/v/release/gojue/moling?display_name=tag&include_prereleases&sort=semver)](https://github.com/gojue/moling/releases)
 
 ---

--- a/README_JA_JP.md
+++ b/README_JA_JP.md
@@ -2,9 +2,9 @@
 
 [English](./README.md) | [中文](./README_ZH_HANS.md) | 日本語
 
-[![GitHub stars](https://img.shields.io/github/stars/gojue/moling.svg?label=Stars&logo=github)](https://github.com/gojue/moling)
-[![GitHub forks](https://img.shields.io/github/forks/gojue/moling?label=Forks&logo=github)](https://github.com/gojue/moling)
-[![CI](https://github.com/gojue/moling/actions/workflows/go-test.yml/badge.svg)](https://github.com/gojue/ecapture/actions/workflows/go-test.yml)
+[![GitHub stars](https://img.shields.io/github/stars/gojue/moling.svg?label=Stars&logo=github)](https://github.com/gojue/moling/stargazers)
+[![GitHub forks](https://img.shields.io/github/forks/gojue/moling?label=Forks&logo=github)](https://github.com/gojue/moling/forks)
+[![CI](https://github.com/gojue/moling/actions/workflows/go-test.yml/badge.svg)](https://github.com/gojue/moling/actions/workflows/go-test.yml)
 [![Github Version](https://img.shields.io/github/v/release/gojue/moling?display_name=tag&include_prereleases&sort=semver)](https://github.com/gojue/moling/releases)
 
 ---

--- a/README_ZH_HANS.md
+++ b/README_ZH_HANS.md
@@ -2,9 +2,9 @@
 
 [English](./README.md) | 中文 | [日本語](./README_JA_JP.md)
 
-[![GitHub stars](https://img.shields.io/github/stars/gojue/moling.svg?label=Stars&logo=github)](https://github.com/gojue/moling)
-[![GitHub forks](https://img.shields.io/github/forks/gojue/moling?label=Forks&logo=github)](https://github.com/gojue/moling)
-[![CI](https://github.com/gojue/moling/actions/workflows/go-test.yml/badge.svg)](https://github.com/gojue/ecapture/actions/workflows/go-test.yml)
+[![GitHub stars](https://img.shields.io/github/stars/gojue/moling.svg?label=Stars&logo=github)](https://github.com/gojue/moling/stargazers)
+[![GitHub forks](https://img.shields.io/github/forks/gojue/moling?label=Forks&logo=github)](https://github.com/gojue/moling/forks)
+[![CI](https://github.com/gojue/moling/actions/workflows/go-test.yml/badge.svg)](https://github.com/gojue/moling/actions/workflows/go-test.yml)
 [![Github Version](https://img.shields.io/github/v/release/gojue/moling?display_name=tag&include_prereleases&sort=semver)](https://github.com/gojue/moling/releases)
 
 ---

--- a/cli/cobrautl/help.go
+++ b/cli/cobrautl/help.go
@@ -96,7 +96,7 @@ GLOBAL OPTIONS:
 	commandUsageTemplate = template.Must(template.New("command_usage").Funcs(templFuncs).Parse(strings.Replace(commandUsage, "\\\n", "", -1)))
 }
 
-func ecaptureFlagUsages(flagSet *pflag.FlagSet) string {
+func molingFlagUsages(flagSet *pflag.FlagSet) string {
 	x := new(bytes.Buffer)
 
 	flagSet.VisitAll(func(flag *pflag.Flag) {
@@ -149,8 +149,8 @@ func UsageFunc(cmd *cobra.Command, version string) error {
 		Version     string
 	}{
 		cmd,
-		ecaptureFlagUsages(cmd.LocalFlags()),
-		ecaptureFlagUsages(cmd.InheritedFlags()),
+		molingFlagUsages(cmd.LocalFlags()),
+		molingFlagUsages(cmd.InheritedFlags()),
 		subCommands,
 		version,
 	})


### PR DESCRIPTION
This pull request includes various updates to the project configuration, build process, and documentation to reflect the new project name "MoLing" and to enhance the release workflow. The most important changes include modifications to the GitHub Actions workflow, updates to the Makefile, and adjustments to the README files for consistency.

Updates to GitHub Actions workflow:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L30-R31): Added `SNAPSHOT_VERSION` environment variable and a new job `upload-release-assets` to handle uploading release assets. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L30-R31) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R44-R47)

Changes to Makefile:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L14-L16): Updated environment echo statements and help descriptions to use "MoLing" instead of "eCapture". [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L14-L16) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L41-R40)

Documentation updates:

* `README.md`, `README_JA_JP.md`, `README_ZH_HANS.md`: Corrected the URLs for GitHub stars, forks, and CI badges to point to the correct paths. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L5-R7) [[2]](diffhunk://#diff-3a1d3fa24005e0ad5ec456b1526025a4d0f7d525309c6254988b0771948fdd4eL5-R7) [[3]](diffhunk://#diff-6ea0f6dab2a83dfaf15ed42299bf2d9bf4c6477c4901ddd6dd0c6cee8676f0eeL5-R7)

Codebase adjustments:

* [`cli/cobrautl/help.go`](diffhunk://#diff-d393abe4a1e57918a73b884c74dd4523effb6eecb4ff9909a947737fd4fed6c2L99-R99): Renamed functions from `ecaptureFlagUsages` to `molingFlagUsages` to reflect the new project name. [[1]](diffhunk://#diff-d393abe4a1e57918a73b884c74dd4523effb6eecb4ff9909a947737fd4fed6c2L99-R99) [[2]](diffhunk://#diff-d393abe4a1e57918a73b884c74dd4523effb6eecb4ff9909a947737fd4fed6c2L152-R153)