### PR TITLE
fix: update README files to replace image links with direct URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ MoLing is a computer-use and browser-use MCP Server that implements system inter
 MoLing in [Claude](https://claude.ai/)
 ![](./images/screenshot_claude.png)
 
-![](https://github.com/user-attachments/assets/229c4dd5-23b4-4b53-9e25-3eba8734b5b7)
+https://github.com/user-attachments/assets/229c4dd5-23b4-4b53-9e25-3eba8734b5b7
 
 #### Configuration Format
 

--- a/README.md
+++ b/README.md
@@ -44,10 +44,11 @@ MoLing is a computer-use and browser-use MCP Server that implements system inter
 - etc. (who support MCP protocol)
 
 #### Demos
-MoLing in [Claude](https://claude.ai/)
-![](./images/screenshot_claude.png)
 
 https://github.com/user-attachments/assets/229c4dd5-23b4-4b53-9e25-3eba8734b5b7
+
+MoLing in [Claude](https://claude.ai/)
+![](./images/screenshot_claude.png)
 
 #### Configuration Format
 

--- a/README_JA_JP.md
+++ b/README_JA_JP.md
@@ -44,10 +44,11 @@ MoLingは、オペレーティングシステムAPIを介してシステム操�
 - その他（MCPプロトコルをサポートするクライアント）
 
 #### スクリーンショット
-[Claude](https://claude.ai/)に統合されたMoLing
-![](./images/screenshot_claude.png)
 
 https://github.com/user-attachments/assets/229c4dd5-23b4-4b53-9e25-3eba8734b5b7
+
+[Claude](https://claude.ai/)に統合されたMoLing
+![](./images/screenshot_claude.png)
 
 #### 設定形式
 

--- a/README_JA_JP.md
+++ b/README_JA_JP.md
@@ -47,7 +47,7 @@ MoLingは、オペレーティングシステムAPIを介してシステム操�
 [Claude](https://claude.ai/)に統合されたMoLing
 ![](./images/screenshot_claude.png)
 
-![](https://github.com/user-attachments/assets/229c4dd5-23b4-4b53-9e25-3eba8734b5b7)
+https://github.com/user-attachments/assets/229c4dd5-23b4-4b53-9e25-3eba8734b5b7
 
 #### 設定形式
 

--- a/README_ZH_HANS.md
+++ b/README_ZH_HANS.md
@@ -47,7 +47,7 @@ MoLing是一个computer-use和browser-use的MCP Server，基于操作系统API�
 集成在[Claude](https://claude.ai/)中的MoLing
 ![](./images/screenshot_claude.png)
 
-![](https://github.com/user-attachments/assets/229c4dd5-23b4-4b53-9e25-3eba8734b5b7)
+https://github.com/user-attachments/assets/229c4dd5-23b4-4b53-9e25-3eba8734b5b7
 
 #### 配置格式
 

--- a/README_ZH_HANS.md
+++ b/README_ZH_HANS.md
@@ -44,10 +44,11 @@ MoLing是一个computer-use和browser-use的MCP Server，基于操作系统API�
 - 其他（支持MCP协议的客户端）
 
 #### 演示
-集成在[Claude](https://claude.ai/)中的MoLing
-![](./images/screenshot_claude.png)
 
 https://github.com/user-attachments/assets/229c4dd5-23b4-4b53-9e25-3eba8734b5b7
+
+集成在[Claude](https://claude.ai/)中的MoLing
+![](./images/screenshot_claude.png)
 
 #### 配置格式
 


### PR DESCRIPTION
This pull request includes updates to the documentation files in multiple languages to improve the presentation of a demo link and screenshots.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R47-L51): Moved the demo link to a separate line above the screenshot for better clarity.
* [`README_JA_JP.md`](diffhunk://#diff-3a1d3fa24005e0ad5ec456b1526025a4d0f7d525309c6254988b0771948fdd4eR47-L51): Moved the demo link to a separate line above the screenshot for better clarity.
* [`README_ZH_HANS.md`](diffhunk://#diff-6ea0f6dab2a83dfaf15ed42299bf2d9bf4c6477c4901ddd6dd0c6cee8676f0eeR47-L51): Moved the demo link to a separate line above the screenshot for better clarity.