### PR TITLE
feat: add MCP Client configuration to install script

### DIFF
--- a/install/install.ps1
+++ b/install/install.ps1
@@ -44,6 +44,9 @@ Move-Item -Path "moling\moling.exe" -Destination "$destination\moling.exe"
 $env:Path += ";$destination"
 [System.Environment]::SetEnvironmentVariable("Path", $env:Path, [System.EnvironmentVariableTarget]::Machine)
 
+# MCP Client configuration
+& "$destination\moling.exe" client --install
+
 # Clean up
 Remove-Item -Recurse -Force "moling"
 Remove-Item -Force $FILE_NAME

--- a/services/file_system_windows.go
+++ b/services/file_system_windows.go
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2025 CFC4N <cfc4n.cs@gmail.com>. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Repository: https://github.com/gojue/moling
+ */
+
+package services
+
+import "os"
+
+func init() {
+	dirName, err := os.UserCacheDir()
+	if err != nil {
+		dirName, err = os.UserHomeDir()
+		if err != nil {
+			return
+		}
+	}
+	allowedDirsDefault = dirName
+}


### PR DESCRIPTION
This pull request includes changes to the `install/install.ps1` and `services/file_system_windows.go` files. The changes focus on adding MCP Client configuration steps and initializing the `allowedDirsDefault` variable in the Windows file system service.

Configuration and Initialization:

* [`install/install.ps1`](diffhunk://#diff-4a74676dc37dee5d10cb083aa0f584c223d773b3692d4640705313e6ab9c629eR47-R49): Added MCP Client configuration step by invoking `moling.exe` with the `client --install` command.
* [`services/file_system_windows.go`](diffhunk://#diff-5fab0ee97283d928f44419ab286fab53a4ca0cf7361e24d390fcb8a4ccaabd05R1-R32): Added a new initialization function to set the `allowedDirsDefault` variable using the user's cache directory or home directory. This change also includes adding a copyright notice and licensing information.

These changes ensure proper configuration of the MCP Client during installation and improve the initialization of the file system service in a Windows environment.