### PR TITLE
feat: update dependencies and add Makefile for multi-platform builds

### DIFF
--- a/Makefile.release
+++ b/Makefile.release
@@ -1,0 +1,35 @@
+include variables.mk
+include functions.mk
+
+.PHONY: all build package clean
+
+# 定义目标系统和架构
+TARGET_SYSTEMS := darwin linux windows
+TARGET_ARCHS := amd64 arm64
+
+# 输出目录
+DIST_DIR := dist
+
+all: build
+
+# 遍历系统和架构，编译程序
+build:
+	@for os in $(TARGET_SYSTEMS); do \
+		for arch in $(TARGET_ARCHS); do \
+			echo "Building for $$os/$$arch..."; \
+			$(MAKE) TARGET_OS=$$os TARGET_ARCH=$$arch ; \
+			echo "Packaging for $$os/$$arch..."; \
+			OUT_DIR=moling\_$$os\_$$arch\_$(COMMIT); \
+			mkdir -p $(DIST_DIR)/$$OUT_DIR; \
+			cp bin/moling$$([ "$$os" = "windows" ] && echo ".exe") $(DIST_DIR)/$$OUT_DIR/; \
+			if [ "$$os" = "windows" ]; then \
+				(cd $(DIST_DIR) && zip -r $$OUT_DIR.zip $$OUT_DIR); \
+            else \
+				(cd $(DIST_DIR) && tar -czf $$OUT_DIR.tar.gz $$OUT_DIR); \
+            fi; \
+		done; \
+	done
+
+# 清理生成的文件
+clean:
+	$(CMD_RM) -rf bin/* $(DIST_DIR)/*

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24.1
 
 require (
 	github.com/chromedp/chromedp v0.13.6
-	github.com/mark3labs/mcp-go v0.18.0
+	github.com/mark3labs/mcp-go v0.20.0
 	github.com/rs/zerolog v1.34.0
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.6
@@ -22,5 +22,5 @@ require (
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
-	golang.org/x/sys v0.31.0 // indirect
+	golang.org/x/sys v0.32.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,8 @@ github.com/mark3labs/mcp-go v0.17.0 h1:5Ps6T7qXr7De/2QTqs9h6BKeZ/qdeUeGrgM5lPzi9
 github.com/mark3labs/mcp-go v0.17.0/go.mod h1:KmJndYv7GIgcPVwEKJjNcbhVQ+hJGJhrCCB/9xITzpE=
 github.com/mark3labs/mcp-go v0.18.0 h1:YuhgIVjNlTG2ZOwmrkORWyPTp0dz1opPEqvsPtySXao=
 github.com/mark3labs/mcp-go v0.18.0/go.mod h1:KmJndYv7GIgcPVwEKJjNcbhVQ+hJGJhrCCB/9xITzpE=
+github.com/mark3labs/mcp-go v0.20.0 h1:NYZDZ10GBKHVz4SdQ2tPFSDFQFKCTrTZJLn4wj6jAaw=
+github.com/mark3labs/mcp-go v0.20.0/go.mod h1:KmJndYv7GIgcPVwEKJjNcbhVQ+hJGJhrCCB/9xITzpE=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=
@@ -68,6 +70,8 @@ golang.org/x/sys v0.29.0 h1:TPYlXGxvx1MGTn2GiZDhnjPA9wZzZeGKHHmKhHYvgaU=
 golang.org/x/sys v0.29.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/sys v0.31.0 h1:ioabZlmFYtWhL+TRYpcnNlLwhyxaM9kWTDEmfnprqik=
 golang.org/x/sys v0.31.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+golang.org/x/sys v0.32.0 h1:s77OFDvIQeibCmezSnk/q6iAfkdiQaJi4VzroCFrN20=
+golang.org/x/sys v0.32.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
This pull request includes several important changes to the build process and dependency updates. The most significant changes are the addition of a new build system in the `Makefile.release` and updates to the `go.mod` file to use newer versions of dependencies.

### Build Process Improvements:
* [`Makefile.release`](diffhunk://#diff-3d6bb466de3c144c10970dff9d469845f107de4f1288364997362e3d96239235R1-R35): Introduced a new build system that includes variables and functions, defines target systems and architectures, and automates the build and packaging process for different OS and architecture combinations.

### Dependency Updates:
* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L7-R7): Updated the version of `github.com/mark3labs/mcp-go` from v0.18.0 to v0.20.0.
* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L25-R25): Updated the version of `golang.org/x/sys` from v0.31.0 to v0.32.0.