### PR TITLE
feat: add JavaScript debugging tools to browser automation

### DIFF
--- a/services/browser.go
+++ b/services/browser.go
@@ -95,8 +95,7 @@ func (bs *BrowserServer) Init() error {
 		chromedp.Flag("disable-blink-features", "AutomationControlled"),
 		chromedp.Flag("enable-automation", false),
 		chromedp.Flag("disable-features", "Translate"),
-		chromedp.Flag("headless", false),
-		// Like in Puppeteer.
+		chromedp.Flag("headless", bs.config.Headless),
 		chromedp.Flag("hide-scrollbars", false),
 		chromedp.Flag("mute-audio", true),
 		chromedp.Flag("disable-infobars", true),
@@ -196,6 +195,58 @@ func (bs *BrowserServer) Init() error {
 			mcp.Required(),
 		),
 	), bs.handleEvaluate)
+
+	bs.AddTool(mcp.NewTool(
+		"browser_debug_enable",
+		mcp.WithDescription("Enable JavaScript debugging"),
+		mcp.WithBoolean("enabled",
+			mcp.Description("Enable or disable debugging"),
+			mcp.Required(),
+		),
+	), bs.handleDebugEnable)
+
+	bs.AddTool(mcp.NewTool(
+		"browser_set_breakpoint",
+		mcp.WithDescription("Set a JavaScript breakpoint"),
+		mcp.WithString("url",
+			mcp.Description("URL of the script"),
+			mcp.Required(),
+		),
+		mcp.WithNumber("line",
+			mcp.Description("Line number"),
+			mcp.Required(),
+		),
+		mcp.WithNumber("column",
+			mcp.Description("Column number (optional)"),
+		),
+		mcp.WithString("condition",
+			mcp.Description("Breakpoint condition (optional)"),
+		),
+	), bs.handleSetBreakpoint)
+
+	bs.AddTool(mcp.NewTool(
+		"browser_remove_breakpoint",
+		mcp.WithDescription("Remove a JavaScript breakpoint"),
+		mcp.WithString("breakpointId",
+			mcp.Description("Breakpoint ID to remove"),
+			mcp.Required(),
+		),
+	), bs.handleRemoveBreakpoint)
+
+	bs.AddTool(mcp.NewTool(
+		"browser_pause",
+		mcp.WithDescription("Pause JavaScript execution"),
+	), bs.handlePause)
+
+	bs.AddTool(mcp.NewTool(
+		"browser_resume",
+		mcp.WithDescription("Resume JavaScript execution"),
+	), bs.handleResume)
+
+	bs.AddTool(mcp.NewTool(
+		"browser_get_callstack",
+		mcp.WithDescription("Get current call stack when paused"),
+	), bs.handleGetCallstack)
 	return nil
 }
 
@@ -237,7 +288,40 @@ func (bs *BrowserServer) handlePrompt(ctx context.Context, request mcp.GetPrompt
 				Role: mcp.RoleUser,
 				Content: mcp.TextContent{
 					Type: "text",
-					Text: fmt.Sprintf("You are an intelligent MCP Server that performs browser tasks, capable of web browsing, button clicking, form filling, and other tasks."),
+					Text: fmt.Sprintf(`
+You are an AI-powered browser automation assistant capable of performing a wide range of web interactions and debugging tasks. Your capabilities include:
+
+1. **Navigation**: Navigate to any specified URL to load web pages.
+
+2. **Screenshot Capture**: Take full-page screenshots or capture specific elements using CSS selectors, with customizable dimensions (default: 1700x1100 pixels).
+
+3. **Element Interaction**:
+   - Click on elements identified by CSS selectors
+   - Hover over specified elements
+   - Fill input fields with provided values
+   - Select options in dropdown menus
+
+4. **JavaScript Execution**:
+   - Run arbitrary JavaScript code in the browser context
+   - Evaluate scripts and return results
+
+5. **Debugging Tools**:
+   - Enable/disable JavaScript debugging mode
+   - Set breakpoints at specific script locations (URL + line number + optional column/condition)
+   - Remove existing breakpoints by ID
+   - Pause and resume script execution
+   - Retrieve current call stack when paused
+
+For all actions requiring element selection, you must use precise CSS selectors. When capturing screenshots, you can specify either the entire page or target specific elements. For debugging operations, you can precisely control execution flow and inspect runtime behavior.
+
+Please provide clear instructions including:
+- The specific action you want performed
+- Required parameters (URLs, selectors, values, etc.)
+- Any optional parameters (dimensions, conditions, etc.)
+- Expected outcomes where relevant
+
+You should confirm actions before execution when dealing with sensitive operations or destructive commands. Report back with clear status updates, success/failure indicators, and any relevant output or captured data.
+`),
 				},
 			},
 		},
@@ -388,7 +472,7 @@ func (bs *BrowserServer) Close() error {
 	bs.cancelAlloc()
 	bs.cancelChrome()
 	// Cancel the context to stop the browser
-	// chromedp.Cancel(bs.ctx)
+	chromedp.Cancel(bs.ctx)
 	return nil
 }
 

--- a/services/browser.go
+++ b/services/browser.go
@@ -472,7 +472,7 @@ func (bs *BrowserServer) Close() error {
 	bs.cancelAlloc()
 	bs.cancelChrome()
 	// Cancel the context to stop the browser
-	chromedp.Cancel(bs.ctx)
+	_ = chromedp.Cancel(bs.ctx)
 	return nil
 }
 

--- a/services/browser_config.go
+++ b/services/browser_config.go
@@ -33,7 +33,6 @@ type BrowserConfig struct {
 	SelectorQueryTimeout int    `json:"selector_query_timeout"` // SelectorQueryTimeout is the timeout for CSS selector queries. time.Second
 	DataPath             string `json:"data_path"`              // DataPath is the path to the data directory.
 	BrowserDataPath      string `json:"browser_data_path"`      // BrowserDataPath is the path to the browser data directory.
-	//logger          *zerolog.Logger
 }
 
 func (cfg *BrowserConfig) Check() error {

--- a/services/browser_debugger.go
+++ b/services/browser_debugger.go
@@ -1,0 +1,183 @@
+// Copyright 2025 CFC4N <cfc4n.cs@gmail.com>. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Repository: https://github.com/gojue/moling
+
+// Package services provides a set of services for the MoLing application.
+package services
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/chromedp/cdproto/target"
+	"github.com/chromedp/chromedp"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// handleDebugEnable handles the enabling and disabling of debugging in the browser.
+func (bs *BrowserServer) handleDebugEnable(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	enabled, ok := request.Params.Arguments["enabled"].(bool)
+	if !ok {
+		return bs.CallToolResultErr("enabled must be a boolean"), nil
+	}
+
+	var err error
+	rctx, cancel := context.WithCancel(bs.ctx)
+	defer cancel()
+
+	if enabled {
+		err = chromedp.Run(rctx, chromedp.ActionFunc(func(ctx context.Context) error {
+			t := chromedp.FromContext(ctx).Target
+			// 使用Execute方法执行AttachToTarget命令
+			params := target.AttachToTarget(t.TargetID).WithFlatten(true)
+			return t.Execute(ctx, "Target.attachToTarget", params, nil)
+		}))
+	} else {
+		err = chromedp.Run(rctx, chromedp.ActionFunc(func(ctx context.Context) error {
+			t := chromedp.FromContext(ctx).Target
+			// 使用Execute方法执行DetachFromTarget命令
+			params := target.DetachFromTarget().WithSessionID(t.SessionID)
+			return t.Execute(ctx, "Target.detachFromTarget", params, nil)
+		}))
+	}
+
+	if err != nil {
+		return bs.CallToolResultErr(fmt.Sprintf("failed to %s debugging: %v",
+			map[bool]string{true: "enable", false: "disable"}[enabled], err)), nil
+	}
+	return bs.CallToolResult(fmt.Sprintf("Debugging %s",
+		map[bool]string{true: "enabled", false: "disabled"}[enabled])), nil
+}
+
+// handleSetBreakpoint handles setting a breakpoint in the browser.
+func (bs *BrowserServer) handleSetBreakpoint(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	url, ok := request.Params.Arguments["url"].(string)
+	if !ok {
+		return bs.CallToolResultErr("url must be a string"), nil
+	}
+
+	line, ok := request.Params.Arguments["line"].(float64)
+	if !ok {
+		return bs.CallToolResultErr("line must be a number"), nil
+	}
+
+	column, _ := request.Params.Arguments["column"].(float64)
+	condition, _ := request.Params.Arguments["condition"].(string)
+
+	var breakpointID string
+	rctx, cancel := context.WithCancel(bs.ctx)
+	defer cancel()
+	err := chromedp.Run(rctx, chromedp.ActionFunc(func(ctx context.Context) error {
+		t := chromedp.FromContext(ctx).Target
+		params := map[string]interface{}{
+			"url":       url,
+			"line":      int(line),
+			"column":    int(column),
+			"condition": condition,
+		}
+
+		var result map[string]interface{}
+		// 使用Execute方法执行Debugger.setBreakpoint命令
+		if err := t.Execute(ctx, "Debugger.setBreakpoint", params, &result); err != nil {
+			return err
+		}
+
+		breakpointID = result["breakpointId"].(string)
+		return nil
+	}))
+
+	if err != nil {
+		return bs.CallToolResultErr(fmt.Sprintf("failed to set breakpoint: %v", err)), nil
+	}
+	return bs.CallToolResult(fmt.Sprintf("Breakpoint set with ID: %s", breakpointID)), nil
+}
+
+// handleRemoveBreakpoint handles removing a breakpoint in the browser.
+func (bs *BrowserServer) handleRemoveBreakpoint(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	breakpointID, ok := request.Params.Arguments["breakpointId"].(string)
+	if !ok {
+		return bs.CallToolResultErr("breakpointId must be a string"), nil
+	}
+	rctx, cancel := context.WithCancel(bs.ctx)
+	defer cancel()
+	err := chromedp.Run(rctx, chromedp.ActionFunc(func(ctx context.Context) error {
+		t := chromedp.FromContext(ctx).Target
+		// 使用Execute方法执行Debugger.removeBreakpoint命令
+		return t.Execute(ctx, "Debugger.removeBreakpoint", map[string]interface{}{
+			"breakpointId": breakpointID,
+		}, nil)
+	}))
+
+	if err != nil {
+		return bs.CallToolResultErr(fmt.Sprintf("failed to remove breakpoint: %v", err)), nil
+	}
+	return bs.CallToolResult(fmt.Sprintf("Breakpoint %s removed", breakpointID)), nil
+}
+
+// handlePause handles pausing the JavaScript execution in the browser.
+func (bs *BrowserServer) handlePause(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	rctx, cancel := context.WithCancel(bs.ctx)
+	defer cancel()
+	err := chromedp.Run(rctx, chromedp.ActionFunc(func(ctx context.Context) error {
+		t := chromedp.FromContext(ctx).Target
+		// 使用Execute方法执行Debugger.pause命令
+		return t.Execute(ctx, "Debugger.pause", nil, nil)
+	}))
+
+	if err != nil {
+		return bs.CallToolResultErr(fmt.Sprintf("failed to pause execution: %v", err)), nil
+	}
+	return bs.CallToolResult("JavaScript execution paused"), nil
+}
+
+// handleResume handles resuming the JavaScript execution in the browser.
+func (bs *BrowserServer) handleResume(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	rctx, cancel := context.WithCancel(bs.ctx)
+	defer cancel()
+	err := chromedp.Run(rctx, chromedp.ActionFunc(func(ctx context.Context) error {
+		t := chromedp.FromContext(ctx).Target
+		// 使用Execute方法执行Debugger.resume命令
+		return t.Execute(ctx, "Debugger.resume", nil, nil)
+	}))
+
+	if err != nil {
+		return bs.CallToolResultErr(fmt.Sprintf("failed to resume execution: %v", err)), nil
+	}
+	return bs.CallToolResult("JavaScript execution resumed"), nil
+}
+
+// handleStepOver handles stepping over the next line of JavaScript code in the browser.
+func (bs *BrowserServer) handleGetCallstack(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	var callstack interface{}
+	rctx, cancel := context.WithCancel(bs.ctx)
+	defer cancel()
+	err := chromedp.Run(rctx, chromedp.ActionFunc(func(ctx context.Context) error {
+		t := chromedp.FromContext(ctx).Target
+		// 使用Execute方法执行Debugger.getStackTrace命令
+		return t.Execute(ctx, "Debugger.getStackTrace", nil, &callstack)
+	}))
+
+	if err != nil {
+		return bs.CallToolResultErr(fmt.Sprintf("failed to get call stack: %v", err)), nil
+	}
+
+	callstackJSON, err := json.Marshal(callstack)
+	if err != nil {
+		return bs.CallToolResultErr(fmt.Sprintf("failed to marshal call stack: %v", err)), nil
+	}
+
+	return bs.CallToolResult(fmt.Sprintf("Current call stack: %s", string(callstackJSON))), nil
+}

--- a/services/browser_debugger.go
+++ b/services/browser_debugger.go
@@ -95,7 +95,11 @@ func (bs *BrowserServer) handleSetBreakpoint(ctx context.Context, request mcp.Ca
 			return err
 		}
 
-		breakpointID = result["breakpointId"].(string)
+		breakpointID, ok = result["breakpointId"].(string)
+		if !ok {
+			breakpointID = ""
+			return fmt.Errorf("failed to get breakpoint ID")
+		}
 		return nil
 	}))
 


### PR DESCRIPTION
This pull request includes significant additions and modifications to the `services/browser.go` and `services/browser_debugger.go` files to enhance browser automation and debugging capabilities. The most important changes include adding new tools for JavaScript debugging, modifying the headless mode configuration, updating the prompt for the browser assistant, and implementing the handling of various debugging tasks.

Enhancements to browser automation and debugging:

* [`services/browser.go`](diffhunk://#diff-d28c280801f4a5ac525d036ee232b3823a6bdf7c800c3127cea2a2c1ef8e9d37L98-R98): Modified the `Init` function to use the `Headless` configuration from `bs.config` instead of a hardcoded value.
* [`services/browser.go`](diffhunk://#diff-d28c280801f4a5ac525d036ee232b3823a6bdf7c800c3127cea2a2c1ef8e9d37R198-R249): Added tools for enabling/disabling JavaScript debugging, setting/removing breakpoints, pausing/resuming script execution, and retrieving the current call stack.
* [`services/browser.go`](diffhunk://#diff-d28c280801f4a5ac525d036ee232b3823a6bdf7c800c3127cea2a2c1ef8e9d37L240-R324): Updated the prompt in the `handlePrompt` function to include detailed descriptions of the browser assistant's capabilities, including new debugging tools.
* [`services/browser.go`](diffhunk://#diff-d28c280801f4a5ac525d036ee232b3823a6bdf7c800c3127cea2a2c1ef8e9d37L391-R475): Enabled the cancellation of the browser context in the `Close` function to properly stop the browser.

New debugging capabilities:

* [`services/browser_debugger.go`](diffhunk://#diff-4a03d7a60cfb9997b85d92439f57640e08bc4a7c9c4b9de7d519dc2696962f52R1-R183): Added a new file to handle various debugging tasks such as enabling/disabling debugging, setting/removing breakpoints, pausing/resuming script execution, and retrieving the current call stack.