### PR TITLE
refactor: replace CallToolResult methods with NewToolResult methods for error handling

### DIFF
--- a/services/browser.go
+++ b/services/browser.go
@@ -337,16 +337,16 @@ func (bs *BrowserServer) handleNavigate(ctx context.Context, request mcp.CallToo
 
 	err := chromedp.Run(bs.ctx, chromedp.Navigate(url))
 	if err != nil {
-		return bs.CallToolResultErr(fmt.Sprintf("failed to navigate: %v", err)), nil
+		return mcp.NewToolResultError(fmt.Sprintf("failed to navigate: %v", err)), nil
 	}
-	return bs.CallToolResult(fmt.Sprintf("Navigated to %s", url)), nil
+	return mcp.NewToolResultText(fmt.Sprintf("Navigated to %s", url)), nil
 }
 
 // handleScreenshot handles the screenshot action.
 func (bs *BrowserServer) handleScreenshot(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	name, ok := request.Params.Arguments["name"].(string)
 	if !ok {
-		return bs.CallToolResultErr("name must be a string"), nil
+		return mcp.NewToolResultError("name must be a string"), nil
 	}
 	selector, _ := request.Params.Arguments["selector"].(string)
 	width, _ := request.Params.Arguments["width"].(int)
@@ -367,22 +367,22 @@ func (bs *BrowserServer) handleScreenshot(ctx context.Context, request mcp.CallT
 		err = chromedp.Run(bs.ctx, chromedp.Screenshot(selector, &buf, chromedp.NodeVisible))
 	}
 	if err != nil {
-		return bs.CallToolResultErr(fmt.Sprintf("failed to take screenshot: %v", err)), nil
+		return mcp.NewToolResultError(fmt.Sprintf("failed to take screenshot: %v", err)), nil
 	}
 
 	newName := filepath.Join(bs.config.DataPath, fmt.Sprintf("%s_%d.png", strings.TrimRight(name, ".png"), rand.Int()))
 	err = os.WriteFile(newName, buf, 0644)
 	if err != nil {
-		return bs.CallToolResultErr(fmt.Sprintf("failed to save screenshot: %v", err)), nil
+		return mcp.NewToolResultError(fmt.Sprintf("failed to save screenshot: %v", err)), nil
 	}
-	return bs.CallToolResult(fmt.Sprintf("Screenshot saved to:%s", newName)), nil
+	return mcp.NewToolResultText(fmt.Sprintf("Screenshot saved to:%s", newName)), nil
 }
 
 // handleClick handles the click action on a specified element.
 func (bs *BrowserServer) handleClick(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	selector, ok := request.Params.Arguments["selector"].(string)
 	if !ok {
-		return bs.CallToolResultErr(fmt.Sprintf("selector must be a string:%v", selector)), nil
+		return mcp.NewToolResultError(fmt.Sprintf("selector must be a string:%v", selector)), nil
 	}
 	runCtx, cancelFunc := context.WithTimeout(bs.ctx, time.Duration(bs.config.SelectorQueryTimeout)*time.Second)
 	defer cancelFunc()
@@ -392,79 +392,79 @@ func (bs *BrowserServer) handleClick(ctx context.Context, request mcp.CallToolRe
 		chromedp.Click(selector, chromedp.NodeVisible),
 	)
 	if err != nil {
-		return bs.CallToolResultErr(fmt.Errorf("failed to click element: %v", err).Error()), nil
+		return mcp.NewToolResultError(fmt.Errorf("failed to click element: %v", err).Error()), nil
 	}
-	return bs.CallToolResult(fmt.Sprintf("Clicked element %s", selector)), nil
+	return mcp.NewToolResultText(fmt.Sprintf("Clicked element %s", selector)), nil
 }
 
 // handleFill handles the fill action on a specified input field.
 func (bs *BrowserServer) handleFill(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	selector, ok := request.Params.Arguments["selector"].(string)
 	if !ok {
-		return bs.CallToolResultErr(fmt.Sprintf("failed to fill selector:%v", request.Params.Arguments["selector"])), nil
+		return mcp.NewToolResultError(fmt.Sprintf("failed to fill selector:%v", request.Params.Arguments["selector"])), nil
 	}
 
 	value, ok := request.Params.Arguments["value"].(string)
 	if !ok {
-		return bs.CallToolResultErr(fmt.Sprintf("failed to fill input field: %v, selector:%v", request.Params.Arguments["value"], selector)), nil
+		return mcp.NewToolResultError(fmt.Sprintf("failed to fill input field: %v, selector:%v", request.Params.Arguments["value"], selector)), nil
 	}
 
 	runCtx, cancelFunc := context.WithTimeout(bs.ctx, time.Duration(bs.config.SelectorQueryTimeout)*time.Second)
 	defer cancelFunc()
 	err := chromedp.Run(runCtx, chromedp.SendKeys(selector, value, chromedp.NodeVisible))
 	if err != nil {
-		return bs.CallToolResultErr(fmt.Sprintf("failed to fill input field: %v", err)), nil
+		return mcp.NewToolResultError(fmt.Sprintf("failed to fill input field: %v", err)), nil
 	}
-	return bs.CallToolResult(fmt.Sprintf("Filled input %s with value %s", selector, value)), nil
+	return mcp.NewToolResultText(fmt.Sprintf("Filled input %s with value %s", selector, value)), nil
 }
 
 func (bs *BrowserServer) handleSelect(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	selector, ok := request.Params.Arguments["selector"].(string)
 	if !ok {
-		return bs.CallToolResultErr(fmt.Sprintf("failed to select selector:%v", request.Params.Arguments["selector"])), nil
+		return mcp.NewToolResultError(fmt.Sprintf("failed to select selector:%v", request.Params.Arguments["selector"])), nil
 	}
 	value, ok := request.Params.Arguments["value"].(string)
 	if !ok {
-		return bs.CallToolResultErr(fmt.Sprintf("failed to select value:%v", request.Params.Arguments["value"])), nil
+		return mcp.NewToolResultError(fmt.Sprintf("failed to select value:%v", request.Params.Arguments["value"])), nil
 	}
 	runCtx, cancelFunc := context.WithTimeout(bs.ctx, time.Duration(bs.config.SelectorQueryTimeout)*time.Second)
 	defer cancelFunc()
 	err := chromedp.Run(runCtx, chromedp.SetValue(selector, value, chromedp.NodeVisible))
 	if err != nil {
-		return bs.CallToolResultErr(fmt.Errorf("failed to select value: %v", err).Error()), nil
+		return mcp.NewToolResultError(fmt.Errorf("failed to select value: %v", err).Error()), nil
 	}
-	return bs.CallToolResult(fmt.Sprintf("Selected value %s for element %s", value, selector)), nil
+	return mcp.NewToolResultText(fmt.Sprintf("Selected value %s for element %s", value, selector)), nil
 }
 
 // handleHover handles the hover action on a specified element.
 func (bs *BrowserServer) handleHover(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	selector, ok := request.Params.Arguments["selector"].(string)
 	if !ok {
-		return bs.CallToolResultErr(fmt.Sprintf("selector must be a string:%v", selector)), nil
+		return mcp.NewToolResultError(fmt.Sprintf("selector must be a string:%v", selector)), nil
 	}
 	var res bool
 	runCtx, cancelFunc := context.WithTimeout(bs.ctx, time.Duration(bs.config.SelectorQueryTimeout)*time.Second)
 	defer cancelFunc()
 	err := chromedp.Run(runCtx, chromedp.Evaluate(`document.querySelector('`+selector+`').dispatchEvent(new Event('mouseover'))`, &res))
 	if err != nil {
-		return bs.CallToolResultErr(fmt.Errorf("failed to hover over element: %v", err).Error()), nil
+		return mcp.NewToolResultError(fmt.Errorf("failed to hover over element: %v", err).Error()), nil
 	}
-	return bs.CallToolResult(fmt.Sprintf("Hovered over element %s, result:%t", selector, res)), nil
+	return mcp.NewToolResultText(fmt.Sprintf("Hovered over element %s, result:%t", selector, res)), nil
 }
 
 func (bs *BrowserServer) handleEvaluate(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	script, ok := request.Params.Arguments["script"].(string)
 	if !ok {
-		return bs.CallToolResultErr("script must be a string"), nil
+		return mcp.NewToolResultError("script must be a string"), nil
 	}
 	var result interface{}
 	runCtx, cancelFunc := context.WithTimeout(bs.ctx, time.Duration(bs.config.SelectorQueryTimeout)*time.Second)
 	defer cancelFunc()
 	err := chromedp.Run(runCtx, chromedp.Evaluate(script, &result))
 	if err != nil {
-		return bs.CallToolResultErr(fmt.Errorf("failed to execute script: %v", err).Error()), nil
+		return mcp.NewToolResultError(fmt.Errorf("failed to execute script: %v", err).Error()), nil
 	}
-	return bs.CallToolResult(fmt.Sprintf("Script executed successfully: %v", result)), nil
+	return mcp.NewToolResultText(fmt.Sprintf("Script executed successfully: %v", result)), nil
 }
 
 func (bs *BrowserServer) Close() error {

--- a/services/browser_debugger.go
+++ b/services/browser_debugger.go
@@ -31,7 +31,7 @@ import (
 func (bs *BrowserServer) handleDebugEnable(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	enabled, ok := request.Params.Arguments["enabled"].(bool)
 	if !ok {
-		return bs.CallToolResultErr("enabled must be a boolean"), nil
+		return mcp.NewToolResultError("enabled must be a boolean"), nil
 	}
 
 	var err error
@@ -55,10 +55,10 @@ func (bs *BrowserServer) handleDebugEnable(ctx context.Context, request mcp.Call
 	}
 
 	if err != nil {
-		return bs.CallToolResultErr(fmt.Sprintf("failed to %s debugging: %v",
+		return mcp.NewToolResultError(fmt.Sprintf("failed to %s debugging: %v",
 			map[bool]string{true: "enable", false: "disable"}[enabled], err)), nil
 	}
-	return bs.CallToolResult(fmt.Sprintf("Debugging %s",
+	return mcp.NewToolResultText(fmt.Sprintf("Debugging %s",
 		map[bool]string{true: "enabled", false: "disabled"}[enabled])), nil
 }
 
@@ -66,12 +66,12 @@ func (bs *BrowserServer) handleDebugEnable(ctx context.Context, request mcp.Call
 func (bs *BrowserServer) handleSetBreakpoint(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	url, ok := request.Params.Arguments["url"].(string)
 	if !ok {
-		return bs.CallToolResultErr("url must be a string"), nil
+		return mcp.NewToolResultError("url must be a string"), nil
 	}
 
 	line, ok := request.Params.Arguments["line"].(float64)
 	if !ok {
-		return bs.CallToolResultErr("line must be a number"), nil
+		return mcp.NewToolResultError("line must be a number"), nil
 	}
 
 	column, _ := request.Params.Arguments["column"].(float64)
@@ -104,16 +104,16 @@ func (bs *BrowserServer) handleSetBreakpoint(ctx context.Context, request mcp.Ca
 	}))
 
 	if err != nil {
-		return bs.CallToolResultErr(fmt.Sprintf("failed to set breakpoint: %v", err)), nil
+		return mcp.NewToolResultError(fmt.Sprintf("failed to set breakpoint: %v", err)), nil
 	}
-	return bs.CallToolResult(fmt.Sprintf("Breakpoint set with ID: %s", breakpointID)), nil
+	return mcp.NewToolResultText(fmt.Sprintf("Breakpoint set with ID: %s", breakpointID)), nil
 }
 
 // handleRemoveBreakpoint handles removing a breakpoint in the browser.
 func (bs *BrowserServer) handleRemoveBreakpoint(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	breakpointID, ok := request.Params.Arguments["breakpointId"].(string)
 	if !ok {
-		return bs.CallToolResultErr("breakpointId must be a string"), nil
+		return mcp.NewToolResultError("breakpointId must be a string"), nil
 	}
 	rctx, cancel := context.WithCancel(bs.ctx)
 	defer cancel()
@@ -126,9 +126,9 @@ func (bs *BrowserServer) handleRemoveBreakpoint(ctx context.Context, request mcp
 	}))
 
 	if err != nil {
-		return bs.CallToolResultErr(fmt.Sprintf("failed to remove breakpoint: %v", err)), nil
+		return mcp.NewToolResultError(fmt.Sprintf("failed to remove breakpoint: %v", err)), nil
 	}
-	return bs.CallToolResult(fmt.Sprintf("Breakpoint %s removed", breakpointID)), nil
+	return mcp.NewToolResultText(fmt.Sprintf("Breakpoint %s removed", breakpointID)), nil
 }
 
 // handlePause handles pausing the JavaScript execution in the browser.
@@ -142,9 +142,9 @@ func (bs *BrowserServer) handlePause(ctx context.Context, request mcp.CallToolRe
 	}))
 
 	if err != nil {
-		return bs.CallToolResultErr(fmt.Sprintf("failed to pause execution: %v", err)), nil
+		return mcp.NewToolResultError(fmt.Sprintf("failed to pause execution: %v", err)), nil
 	}
-	return bs.CallToolResult("JavaScript execution paused"), nil
+	return mcp.NewToolResultText("JavaScript execution paused"), nil
 }
 
 // handleResume handles resuming the JavaScript execution in the browser.
@@ -158,9 +158,9 @@ func (bs *BrowserServer) handleResume(ctx context.Context, request mcp.CallToolR
 	}))
 
 	if err != nil {
-		return bs.CallToolResultErr(fmt.Sprintf("failed to resume execution: %v", err)), nil
+		return mcp.NewToolResultError(fmt.Sprintf("failed to resume execution: %v", err)), nil
 	}
-	return bs.CallToolResult("JavaScript execution resumed"), nil
+	return mcp.NewToolResultText("JavaScript execution resumed"), nil
 }
 
 // handleStepOver handles stepping over the next line of JavaScript code in the browser.
@@ -175,13 +175,13 @@ func (bs *BrowserServer) handleGetCallstack(ctx context.Context, request mcp.Cal
 	}))
 
 	if err != nil {
-		return bs.CallToolResultErr(fmt.Sprintf("failed to get call stack: %v", err)), nil
+		return mcp.NewToolResultError(fmt.Sprintf("failed to get call stack: %v", err)), nil
 	}
 
 	callstackJSON, err := json.Marshal(callstack)
 	if err != nil {
-		return bs.CallToolResultErr(fmt.Sprintf("failed to marshal call stack: %v", err)), nil
+		return mcp.NewToolResultError(fmt.Sprintf("failed to marshal call stack: %v", err)), nil
 	}
 
-	return bs.CallToolResult(fmt.Sprintf("Current call stack: %s", string(callstackJSON))), nil
+	return mcp.NewToolResultText(fmt.Sprintf("Current call stack: %s", string(callstackJSON))), nil
 }

--- a/services/command.go
+++ b/services/command.go
@@ -118,22 +118,22 @@ func (cs *CommandServer) handlePrompt(ctx context.Context, request mcp.GetPrompt
 func (cs *CommandServer) handleExecuteCommand(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	command, ok := request.Params.Arguments["command"].(string)
 	if !ok {
-		return cs.CallToolResultErr(fmt.Errorf("command must be a string").Error()), nil
+		return mcp.NewToolResultError(fmt.Errorf("command must be a string").Error()), nil
 	}
 
 	// Check if the command is allowed
 	if !cs.isAllowedCommand(command) {
 		cs.logger.Err(ErrCommandNotAllowed).Str("command", command).Msgf("If you want to allow this command, add it to %s", filepath.Join(cs.MlConfig().BasePath, "config", cs.MlConfig().ConfigFile))
-		return cs.CallToolResultErr(fmt.Sprintf("Error: Command '%s' is not allowed", command)), nil
+		return mcp.NewToolResultError(fmt.Sprintf("Error: Command '%s' is not allowed", command)), nil
 	}
 
 	// Execute the command
 	output, err := ExecCommand(command)
 	if err != nil {
-		return cs.CallToolResultErr(fmt.Sprintf("Error executing command: %v", err)), nil
+		return mcp.NewToolResultError(fmt.Sprintf("Error executing command: %v", err)), nil
 	}
 
-	return cs.CallToolResult(output), nil
+	return mcp.NewToolResultText(output), nil
 }
 
 // isAllowedCommand checks if the command is allowed based on the configuration.

--- a/services/service.go
+++ b/services/service.go
@@ -190,29 +190,6 @@ func (mls *MLService) NotificationHandlers() map[string]server.NotificationHandl
 	return mls.notificationHandlers
 }
 
-// CallToolResult return a CallToolResult with the given message and success status.
-func (mls *MLService) CallToolResult(msg string) *mcp.CallToolResult {
-	return mls.callToolResult(false, msg)
-}
-
-// CallToolResultErr return a CallToolResult with the given message and error status.
-func (mls *MLService) CallToolResultErr(msg string) *mcp.CallToolResult {
-	return mls.callToolResult(true, msg)
-}
-
-// callToolResult returns a CallToolResult with the given message and error status. Not allowed to be called directly.
-func (mls *MLService) callToolResult(isError bool, msg string) *mcp.CallToolResult {
-	return &mcp.CallToolResult{
-		Content: []mcp.Content{
-			mcp.TextContent{
-				Type: "text",
-				Text: msg,
-			},
-		},
-		IsError: isError,
-	}
-}
-
 // MlConfig returns the configuration of the MoLing service.
 func (mls *MLService) MlConfig() *MoLingConfig {
 	return mls.mlConfig


### PR DESCRIPTION

This pull request involves refactoring error handling and result reporting methods in several service files to use a unified approach. The changes replace custom error and result handling methods with standardized methods from the `mcp` package.

### Error Handling and Result Reporting Standardization:

* [`services/browser.go`](diffhunk://#diff-d28c280801f4a5ac525d036ee232b3823a6bdf7c800c3127cea2a2c1ef8e9d37L340-R349): Replaced `bs.CallToolResultErr` and `bs.CallToolResult` with `mcp.NewToolResultError` and `mcp.NewToolResultText` respectively in various methods such as `handleNavigate`, `handleScreenshot`, `handleClick`, `handleFill`, `handleSelect`, `handleHover`, and `handleEvaluate`. [[1]](diffhunk://#diff-d28c280801f4a5ac525d036ee232b3823a6bdf7c800c3127cea2a2c1ef8e9d37L340-R349) [[2]](diffhunk://#diff-d28c280801f4a5ac525d036ee232b3823a6bdf7c800c3127cea2a2c1ef8e9d37L370-R385) [[3]](diffhunk://#diff-d28c280801f4a5ac525d036ee232b3823a6bdf7c800c3127cea2a2c1ef8e9d37L395-R467)
* [`services/browser_debugger.go`](diffhunk://#diff-4a03d7a60cfb9997b85d92439f57640e08bc4a7c9c4b9de7d519dc2696962f52L34-R34): Updated methods like `handleDebugEnable`, `handleSetBreakpoint`, `handleRemoveBreakpoint`, `handlePause`, `handleResume`, and `handleGetCallstack` to use `mcp.NewToolResultError` and `mcp.NewToolResultText` instead of `bs.CallToolResultErr` and `bs.CallToolResult`. [[1]](diffhunk://#diff-4a03d7a60cfb9997b85d92439f57640e08bc4a7c9c4b9de7d519dc2696962f52L34-R34) [[2]](diffhunk://#diff-4a03d7a60cfb9997b85d92439f57640e08bc4a7c9c4b9de7d519dc2696962f52L58-R74) [[3]](diffhunk://#diff-4a03d7a60cfb9997b85d92439f57640e08bc4a7c9c4b9de7d519dc2696962f52L107-R116) [[4]](diffhunk://#diff-4a03d7a60cfb9997b85d92439f57640e08bc4a7c9c4b9de7d519dc2696962f52L129-R131) [[5]](diffhunk://#diff-4a03d7a60cfb9997b85d92439f57640e08bc4a7c9c4b9de7d519dc2696962f52L145-R147) [[6]](diffhunk://#diff-4a03d7a60cfb9997b85d92439f57640e08bc4a7c9c4b9de7d519dc2696962f52L161-R163) [[7]](diffhunk://#diff-4a03d7a60cfb9997b85d92439f57640e08bc4a7c9c4b9de7d519dc2696962f52L178-R186)
* [`services/command.go`](diffhunk://#diff-255513b4527fd7bbbf2e847c570842c03e574d5974694b8ee056e8bc44a3def3L121-R136): Modified `handleExecuteCommand` to replace `cs.CallToolResultErr` and `cs.CallToolResult` with `mcp.NewToolResultError` and `mcp.NewToolResultText`.
* [`services/file_system.go`](diffhunk://#diff-9a13114116d4338e383f0bae89b2c6d18dfa8d77bbd655742cc80646411f099fL428-R441): Updated methods like `handleReadFile`, `handleWriteFile`, `handleListDirectory`, and `handleCreateDirectory` to use `mcp.NewToolResultError` and `mcp.NewToolResultText` instead of `fss.CallToolResultErr` and `fss.CallToolResult`. [[1]](diffhunk://#diff-9a13114116d4338e383f0bae89b2c6d18dfa8d77bbd655742cc80646411f099fL428-R441) [[2]](diffhunk://#diff-9a13114116d4338e383f0bae89b2c6d18dfa8d77bbd655742cc80646411f099fL493-R499) [[3]](diffhunk://#diff-9a13114116d4338e383f0bae89b2c6d18dfa8d77bbd655742cc80646411f099fL583-R587) [[4]](diffhunk://#diff-9a13114116d4338e383f0bae89b2c6d18dfa8d77bbd655742cc80646411f099fL607-R624) [[5]](diffhunk://#diff-9a13114116d4338e383f0bae89b2c6d18dfa8d77bbd655742cc80646411f099fL649-R669) [[6]](diffhunk://#diff-9a13114116d4338e383f0bae89b2c6d18dfa8d77bbd655742cc80646411f099fL715-R720) [[7]](diffhunk://#diff-9a13114116d4338e383f0bae89b2c6d18dfa8d77bbd655742cc80646411f099fL744-R748)