### PR TITLE
support Cursor IDE (MCP  Client)

### DIFF
--- a/client/client_config.go
+++ b/client/client_config.go
@@ -35,4 +35,5 @@ func init() {
 	clientLists["Trae CN Roo"] = filepath.Join(os.Getenv("HOME"), "Library", "Application Support", "Trae CN", "User", "globalStorage", "rooveterinaryinc.roo-cline", "settings", "mcp_settings.json")
 	clientLists["Trae Roo"] = filepath.Join(os.Getenv("HOME"), "Library", "Application Support", "Trae", "User", "globalStorage", "rooveterinaryinc.roo-cline", "settings", "mcp_settings.json")
 	clientLists["Claude"] = filepath.Join(os.Getenv("HOME"), "Library", "Application Support", "Claude", "claude_desktop_config.json")
+	clientLists["Cursor"] = filepath.Join(os.Getenv("HOME"), ".cursor", "mcp.json")
 }

--- a/client/client_config_windows.go
+++ b/client/client_config_windows.go
@@ -33,4 +33,5 @@ func init() {
 	clientLists["Trae CN Roo"] = filepath.Join(os.Getenv("APPDATA"), "Trae CN", "User", "globalStorage", "saoudrizwan.claude-dev", "settings", "mcp_settings.json")
 	clientLists["Trae Roo"] = filepath.Join(os.Getenv("APPDATA"), "Trae", "User", "globalStorage", "saoudrizwan.claude-dev", "settings", "mcp_settings.json")
 	clientLists["Claude"] = filepath.Join(os.Getenv("APPDATA"), "Claude", "claude_desktop_config.json")
+	clientLists["Cursor"] = filepath.Join(os.Getenv("APPDATA"), "Cursor", "mcp.json")
 }


### PR DESCRIPTION
This pull request adds support for a new client configuration file for "Cursor" on both macOS and Windows platforms by updating the `clientLists` map in the respective configuration files.

Platform-specific changes:

* [`client/client_config.go`](diffhunk://#diff-5bb8a51ea0a9cc95b06e9b870940ebed593bd6864b5e2e77d6cec085e201de94R38): Added an entry for "Cursor" pointing to the configuration file located at `~/.cursor/mcp.json` on macOS.
* [`client/client_config_windows.go`](diffhunk://#diff-bb26f7c83997799f6cdde45671aede1217d622bce555e131a7ac532b79c38bbaR36): Added an entry for "Cursor" pointing to the configuration file located at `%APPDATA%\Roaming\Cursor\mcp.json` on Windows.