### PR TITLE
feat: update prompts for browser, command, and filesystem assistants

### DIFF
--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -139,7 +139,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&mlConfig.BasePath, "base_path", mlConfig.BasePath, "MoLing Base Data Path, automatically set by the system, cannot be changed, display only.")
 	rootCmd.PersistentFlags().BoolVarP(&mlConfig.Debug, "debug", "d", false, "Debug mode, default is false.")
 	rootCmd.PersistentFlags().StringVarP(&mlConfig.ListenAddr, "listen_addr", "l", "", "listen address for SSE mode. default:'', not listen, used STDIO mode.")
-	rootCmd.PersistentFlags().StringVarP(&mlConfig.Module, "module", "m", "all", "module to load, default: all; others: browser, filesystem, command, etc. Multiple modules are separated by commas")
+	rootCmd.PersistentFlags().StringVarP(&mlConfig.Module, "module", "m", "all", "module to load, default: all; others: Browser,FileSystem,Command, etc. Multiple modules are separated by commas")
 	rootCmd.SilenceUsage = true
 }
 

--- a/go.mod
+++ b/go.mod
@@ -3,17 +3,17 @@ module github.com/gojue/moling
 go 1.24.1
 
 require (
+	github.com/chromedp/cdproto v0.0.0-20250417220500-b38043e8e6c8
 	github.com/chromedp/chromedp v0.13.6
-	github.com/mark3labs/mcp-go v0.21.0
+	github.com/mark3labs/mcp-go v0.21.1
 	github.com/rs/zerolog v1.34.0
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.6
 )
 
 require (
-	github.com/chromedp/cdproto v0.0.0-20250416210000-d7e4d624041a // indirect
 	github.com/chromedp/sysutil v1.1.0 // indirect
-	github.com/go-json-experiment/json v0.0.0-20250223041408-d3c622f1b874 // indirect
+	github.com/go-json-experiment/json v0.0.0-20250417205406-170dfdcf87d1 // indirect
 	github.com/gobwas/httphead v0.1.0 // indirect
 	github.com/gobwas/pool v0.2.1 // indirect
 	github.com/gobwas/ws v1.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/chromedp/cdproto v0.0.0-20250403032234-65de8f5d025b h1:jJmiCljLNTaq/O
 github.com/chromedp/cdproto v0.0.0-20250403032234-65de8f5d025b/go.mod h1:NItd7aLkcfOA/dcMXvl8p1u+lQqioRMq/SqDp71Pb/k=
 github.com/chromedp/cdproto v0.0.0-20250416210000-d7e4d624041a h1:TVjyMfX22UgV/jP0A4UwrrCmI9zfvp6ZS5UBZMy3HDw=
 github.com/chromedp/cdproto v0.0.0-20250416210000-d7e4d624041a/go.mod h1:NItd7aLkcfOA/dcMXvl8p1u+lQqioRMq/SqDp71Pb/k=
+github.com/chromedp/cdproto v0.0.0-20250417220500-b38043e8e6c8 h1:j1b2XORm5Zh5jhTu8rH8AoRnrdT1V4x00OrBXU8Qzs4=
+github.com/chromedp/cdproto v0.0.0-20250417220500-b38043e8e6c8/go.mod h1:NItd7aLkcfOA/dcMXvl8p1u+lQqioRMq/SqDp71Pb/k=
 github.com/chromedp/chromedp v0.13.3 h1:c6nTn97XQBykzcXiGYL5LLebw3h3CEyrCihm4HquYh0=
 github.com/chromedp/chromedp v0.13.3/go.mod h1:khsDP9OP20GrowpJfZ7N05iGCwcAYxk7qf9AZBzR3Qw=
 github.com/chromedp/chromedp v0.13.6 h1:xlNunMyzS5bu3r/QKrb3fzX6ow3WBQ6oao+J65PGZxk=
@@ -18,6 +20,8 @@ github.com/go-json-experiment/json v0.0.0-20250211171154-1ae217ad3535 h1:yE7argO
 github.com/go-json-experiment/json v0.0.0-20250211171154-1ae217ad3535/go.mod h1:BWmvoE1Xia34f3l/ibJweyhrT+aROb/FQ6d+37F0e2s=
 github.com/go-json-experiment/json v0.0.0-20250223041408-d3c622f1b874 h1:F8d1AJ6M9UQCavhwmO6ZsrYLfG8zVFWfEfMS2MXPkSY=
 github.com/go-json-experiment/json v0.0.0-20250223041408-d3c622f1b874/go.mod h1:TiCD2a1pcmjd7YnhGH0f/zKNcCD06B029pHhzV23c2M=
+github.com/go-json-experiment/json v0.0.0-20250417205406-170dfdcf87d1 h1:+VexzzkMLb1tnvpuQdGT/DicIRW7MN8ozsXqBMgp0Hk=
+github.com/go-json-experiment/json v0.0.0-20250417205406-170dfdcf87d1/go.mod h1:TiCD2a1pcmjd7YnhGH0f/zKNcCD06B029pHhzV23c2M=
 github.com/gobwas/httphead v0.1.0 h1:exrUm0f4YX0L7EBwZHuCF4GDp8aJfVeBrlLQrs6NqWU=
 github.com/gobwas/httphead v0.1.0/go.mod h1:O/RXo79gxV8G+RqlR/otEwx4Q36zl9rqC5u12GKvMCM=
 github.com/gobwas/pool v0.2.1 h1:xfeeEhW7pwmX8nuLVlqbzVc7udMDrwetjEv+TZIz1og=
@@ -43,6 +47,8 @@ github.com/mark3labs/mcp-go v0.20.1 h1:E1Bbx9K8d8kQmDZ1QHblM38c7UU2evQ2LlkANk1U/
 github.com/mark3labs/mcp-go v0.20.1/go.mod h1:KmJndYv7GIgcPVwEKJjNcbhVQ+hJGJhrCCB/9xITzpE=
 github.com/mark3labs/mcp-go v0.21.0 h1:oyEtiXg8PnrVEFis9b1AwbiUWF2dTbyBP5yLo7SruXE=
 github.com/mark3labs/mcp-go v0.21.0/go.mod h1:KmJndYv7GIgcPVwEKJjNcbhVQ+hJGJhrCCB/9xITzpE=
+github.com/mark3labs/mcp-go v0.21.1 h1:7Ek6KPIIbMhEYHRiRIg6K6UAgNZCJaHKQp926MNr6V0=
+github.com/mark3labs/mcp-go v0.21.1/go.mod h1:KmJndYv7GIgcPVwEKJjNcbhVQ+hJGJhrCCB/9xITzpE=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=

--- a/services/browser.go
+++ b/services/browser.go
@@ -289,40 +289,7 @@ func (bs *BrowserServer) handlePrompt(ctx context.Context, request mcp.GetPrompt
 				Role: mcp.RoleUser,
 				Content: mcp.TextContent{
 					Type: "text",
-					Text: fmt.Sprintf(`
-You are an AI-powered browser automation assistant capable of performing a wide range of web interactions and debugging tasks. Your capabilities include:
-
-1. **Navigation**: Navigate to any specified URL to load web pages.
-
-2. **Screenshot Capture**: Take full-page screenshots or capture specific elements using CSS selectors, with customizable dimensions (default: 1700x1100 pixels).
-
-3. **Element Interaction**:
-   - Click on elements identified by CSS selectors
-   - Hover over specified elements
-   - Fill input fields with provided values
-   - Select options in dropdown menus
-
-4. **JavaScript Execution**:
-   - Run arbitrary JavaScript code in the browser context
-   - Evaluate scripts and return results
-
-5. **Debugging Tools**:
-   - Enable/disable JavaScript debugging mode
-   - Set breakpoints at specific script locations (URL + line number + optional column/condition)
-   - Remove existing breakpoints by ID
-   - Pause and resume script execution
-   - Retrieve current call stack when paused
-
-For all actions requiring element selection, you must use precise CSS selectors. When capturing screenshots, you can specify either the entire page or target specific elements. For debugging operations, you can precisely control execution flow and inspect runtime behavior.
-
-Please provide clear instructions including:
-- The specific action you want performed
-- Required parameters (URLs, selectors, values, etc.)
-- Any optional parameters (dimensions, conditions, etc.)
-- Expected outcomes where relevant
-
-You should confirm actions before execution when dealing with sensitive operations or destructive commands. Report back with clear status updates, success/failure indicators, and any relevant output or captured data.
-`),
+					Text: bs.config.prompt,
 				},
 			},
 		},
@@ -473,8 +440,9 @@ func (bs *BrowserServer) Close() error {
 	bs.cancelAlloc()
 	bs.cancelChrome()
 	// Cancel the context to stop the browser
-	//_ = chromedp.Cancel(bs.ctx)
-	return nil
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	return chromedp.Cancel(ctx)
 }
 
 // Config returns the configuration of the service as a string.

--- a/services/command.go
+++ b/services/command.go
@@ -107,45 +107,7 @@ func (cs *CommandServer) handlePrompt(ctx context.Context, request mcp.GetPrompt
 				Role: mcp.RoleUser,
 				Content: mcp.TextContent{
 					Type: "text",
-					Text: fmt.Sprintf(`
-You are a powerful terminal command assistant capable of executing various command-line on %s operations and management tasks. Your capabilities include:
-
-1. **File and Directory Management**:
-    - List files and subdirectories in a directory
-    - Create new files or directories
-    - Delete specified files or directories
-    - Copy and move files and directories
-    - Rename files or directories
-
-2. **File Content Operations**:
-    - View the contents of text files
-    - Edit file contents
-    - Redirect output to a file
-    - Search file contents
-
-3. **System Information Retrieval**:
-    - Retrieve system information (e.g., CPU usage, memory usage, etc.)
-    - View the current user and their permissions
-    - Check the current working directory
-
-4. **Network Operations**:
-    - Check network connection status (e.g., using the ping command)
-    - Query domain information (e.g., using the whois command)
-    - Manage network services (e.g., start, stop, and restart services)
-
-5. **Process Management**:
-    - List currently running processes
-    - Terminate specified processes
-    - Adjust process priorities
-
-Before executing any actions, please provide clear instructions, including:
-- The specific command you want to execute
-- Required parameters (file paths, directory names, etc.)
-- Any optional parameters (e.g., modification options, output formats, etc.)
-- Relevant expected results or output
-
-When dealing with sensitive operations or destructive commands, please confirm before execution. Report back with clear status updates, success/failure indicators, and any relevant output or results.
-`, cs.MlConfig().SystemInfo),
+					Text: fmt.Sprintf(cs.config.prompt, cs.MlConfig().SystemInfo),
 				},
 			},
 		},

--- a/services/command_config.go
+++ b/services/command_config.go
@@ -18,11 +18,56 @@ package services
 
 import (
 	"fmt"
+	"os"
 	"strings"
+)
+
+const (
+	CommandPromptDefault = `
+You are a powerful terminal command assistant capable of executing various command-line on %s operations and management tasks. Your capabilities include:
+
+1. **File and Directory Management**:
+    - List files and subdirectories in a directory
+    - Create new files or directories
+    - Delete specified files or directories
+    - Copy and move files and directories
+    - Rename files or directories
+
+2. **File Content Operations**:
+    - View the contents of text files
+    - Edit file contents
+    - Redirect output to a file
+    - Search file contents
+
+3. **System Information Retrieval**:
+    - Retrieve system information (e.g., CPU usage, memory usage, etc.)
+    - View the current user and their permissions
+    - Check the current working directory
+
+4. **Network Operations**:
+    - Check network connection status (e.g., using the ping command)
+    - Query domain information (e.g., using the whois command)
+    - Manage network services (e.g., start, stop, and restart services)
+
+5. **Process Management**:
+    - List currently running processes
+    - Terminate specified processes
+    - Adjust process priorities
+
+Before executing any actions, please provide clear instructions, including:
+- The specific command you want to execute
+- Required parameters (file paths, directory names, etc.)
+- Any optional parameters (e.g., modification options, output formats, etc.)
+- Relevant expected results or output
+
+When dealing with sensitive operations or destructive commands, please confirm before execution. Report back with clear status updates, success/failure indicators, and any relevant output or results.
+`
 )
 
 // CommandConfig represents the configuration for allowed commands.
 type CommandConfig struct {
+	PromptFile      string `json:"prompt_file"` // PromptFile is the prompt file for the command.
+	prompt          string
 	AllowedCommand  string `json:"allowed_command"` // AllowedCommand is a list of allowed command. split by comma. e.g. ls,cat,echo
 	allowedCommands []string
 }
@@ -49,6 +94,7 @@ func NewCommandConfig() *CommandConfig {
 
 // Check validates the allowed commands in the CommandConfig.
 func (cc *CommandConfig) Check() error {
+	cc.prompt = CommandPromptDefault
 	var cnt int
 	cnt = len(cc.allowedCommands)
 
@@ -62,6 +108,12 @@ func (cc *CommandConfig) Check() error {
 	if cnt <= 0 {
 		return fmt.Errorf("no allowed commands specified")
 	}
-
+	if cc.PromptFile != "" {
+		read, err := os.ReadFile(cc.PromptFile)
+		if err != nil {
+			return fmt.Errorf("failed to read prompt file:%s, error: %v", cc.PromptFile, err)
+		}
+		cc.prompt = string(read)
+	}
 	return nil
 }

--- a/services/file_system.go
+++ b/services/file_system.go
@@ -192,38 +192,7 @@ func (fs *FilesystemServer) handlePrompt(ctx context.Context, request mcp.GetPro
 				Role: mcp.RoleUser,
 				Content: mcp.TextContent{
 					Type: "text",
-					Text: fmt.Sprintf(`
-You are a powerful local filesystem management assistant capable of performing various file operations and management tasks. Your capabilities include:
-
-1. **File Browsing**: Navigate to specified directories to load lists of files and folders.
-
-2. **File Operations**:
-   - Create new files or folders
-   - Delete specified files or folders
-   - Copy and move files and folders
-   - Rename files or folders
-
-3. **File Content Operations**:
-   - Read the contents of text files and return them
-   - Write text to specified files
-   - Append content to existing files
-
-4. **File Information Retrieval**:
-   - Retrieve properties of files or folders (e.g., size, creation date, modification date)
-   - Check if files or folders exist
-
-5. **Search Functionality**:
-   - Search for files in specified directories, supporting wildcard matching
-   - Filter search results by file type or modification date
-
-For all actions, please provide clear instructions, including:
-- The specific action you want to perform
-- Required parameters (directory paths, filenames, content, etc.)
-- Any optional parameters (e.g., new filenames, search patterns, etc.)
-- Relevant expected outcomes
-
-You should confirm actions before execution when dealing with sensitive operations or destructive commands. Report back with clear status updates, success/failure indicators, and any relevant output or results.
-`),
+					Text: fs.config.prompt,
 				},
 			},
 		},

--- a/services/file_system_config.go
+++ b/services/file_system_config.go
@@ -23,12 +23,50 @@ import (
 	"strings"
 )
 
+const (
+	// FileSystemPromptDefault is the default prompt for the file system.
+	FileSystemPromptDefault = `
+You are a powerful local filesystem management assistant capable of performing various file operations and management tasks. Your capabilities include:
+
+1. **File Browsing**: Navigate to specified directories to load lists of files and folders.
+
+2. **File Operations**:
+   - Create new files or folders
+   - Delete specified files or folders
+   - Copy and move files and folders
+   - Rename files or folders
+
+3. **File Content Operations**:
+   - Read the contents of text files and return them
+   - Write text to specified files
+   - Append content to existing files
+
+4. **File Information Retrieval**:
+   - Retrieve properties of files or folders (e.g., size, creation date, modification date)
+   - Check if files or folders exist
+
+5. **Search Functionality**:
+   - Search for files in specified directories, supporting wildcard matching
+   - Filter search results by file type or modification date
+
+For all actions, please provide clear instructions, including:
+- The specific action you want to perform
+- Required parameters (directory paths, filenames, content, etc.)
+- Any optional parameters (e.g., new filenames, search patterns, etc.)
+- Relevant expected outcomes
+
+You should confirm actions before execution when dealing with sensitive operations or destructive commands. Report back with clear status updates, success/failure indicators, and any relevant output or results.
+`
+)
+
 var (
 	allowedDirsDefault = os.TempDir()
 )
 
 // FileSystemConfig represents the configuration for the file system.
 type FileSystemConfig struct {
+	PromptFile  string `json:"prompt_file"` // PromptFile is the prompt file for the file system.
+	prompt      string
 	AllowedDir  string `json:"allowed_dir"` // AllowedDirs is a list of allowed directories. split by comma. e.g. /tmp,/var/tmp
 	allowedDirs []string
 	CachePath   string `json:"cache_path"` // CachePath is the root path for the file system.
@@ -52,6 +90,7 @@ func NewFileSystemConfig(path string) *FileSystemConfig {
 
 // Check validates the allowed directories in the FileSystemConfig.
 func (fc *FileSystemConfig) Check() error {
+	fc.prompt = FileSystemPromptDefault
 	normalized := make([]string, 0, len(fc.allowedDirs))
 	for _, dir := range fc.allowedDirs {
 		abs, err := filepath.Abs(strings.TrimSpace(dir))
@@ -69,5 +108,14 @@ func (fc *FileSystemConfig) Check() error {
 		normalized = append(normalized, filepath.Clean(abs)+string(filepath.Separator))
 	}
 	fc.allowedDirs = normalized
+
+	if fc.PromptFile != "" {
+		read, err := os.ReadFile(fc.PromptFile)
+		if err != nil {
+			return fmt.Errorf("failed to read prompt file:%s, error: %v", fc.PromptFile, err)
+		}
+		fc.prompt = string(read)
+	}
+
 	return nil
 }


### PR DESCRIPTION
This pull request introduces several updates aimed at improving the flexibility and maintainability of the configuration and prompt-handling mechanisms across multiple services (`BrowserServer`, `CommandServer`, and `FilesystemServer`). The changes include replacing hardcoded prompts with configurable defaults, adding support for external prompt files, and updating dependencies.

### Prompt Configuration Enhancements:
* **Centralized Default Prompts**: Added default prompts as constants (`BrowserPromptDefault`, `CommandPromptDefault`, `FileSystemPromptDefault`) for `BrowserServer`, `CommandServer`, and `FilesystemServer` to improve maintainability. [[1]](diffhunk://#diff-903ed546f716dd3c4194a0d4400edb856c2aaff7ef38782294f538ed0cf65b7eR26-R63) [[2]](diffhunk://#diff-57d7ce15f7c1f27dddc6ea04860cf324dd5bbaf0b4663744d583bc4acb26c03dR21-R70) [[3]](diffhunk://#diff-8e8dc65e6e617424f1c970a1581bf9787d0a6146a2f45fa9101ef4421d804a95R26-R69)
* **External Prompt File Support**: Introduced a `PromptFile` field in configuration structs (`BrowserConfig`, `CommandConfig`, `FileSystemConfig`) to allow loading prompts from external files, with fallback to the default prompts. [[1]](diffhunk://#diff-903ed546f716dd3c4194a0d4400edb856c2aaff7ef38782294f538ed0cf65b7eR86-R92) [[2]](diffhunk://#diff-57d7ce15f7c1f27dddc6ea04860cf324dd5bbaf0b4663744d583bc4acb26c03dL65-R117) [[3]](diffhunk://#diff-8e8dc65e6e617424f1c970a1581bf9787d0a6146a2f45fa9101ef4421d804a95R111-R119)
* **Dynamic Prompt Usage**: Updated prompt-handling logic in `handlePrompt` methods to use the dynamically loaded prompt instead of hardcoded text. [[1]](diffhunk://#diff-d28c280801f4a5ac525d036ee232b3823a6bdf7c800c3127cea2a2c1ef8e9d37L292-R292) [[2]](diffhunk://#diff-255513b4527fd7bbbf2e847c570842c03e574d5974694b8ee056e8bc44a3def3L110-R110) [[3]](diffhunk://#diff-9a13114116d4338e383f0bae89b2c6d18dfa8d77bbd655742cc80646411f099fL195-R195)

### Dependency Updates:
* **Dependency Version Updates**: Upgraded several dependencies in `go.mod`, including `github.com/mark3labs/mcp-go` (v0.21.0 → v0.21.1) and `github.com/go-json-experiment/json`. Added `github.com/chromedp/cdproto` as a new dependency.

### Miscellaneous Improvements:
* **Browser Context Cleanup**: Improved resource cleanup in the `Close` method of `BrowserServer` by introducing a timeout for the Chrome context cancellation.
* **Documentation and Naming**: Updated the description of the `module` flag in `cli/cmd/root.go` to use consistent capitalization for module names (e.g., `Browser`, `FileSystem`).