### PR TITLE
feat: update command arguments and add new client configurations for Trae and Trae CN

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -51,7 +51,7 @@ func NewMCPServerConfig(description string, command string, srvName string) MCPS
 		Description: description,
 		IsActive:    true,
 		Command:     command,
-		Args:        []string{}, // not used
+		Args:        []string{"-m", "all"},
 		BaseUrl:     "",
 		ServerName:  srvName,
 		TimeOut:     300,

--- a/client/client_config.go
+++ b/client/client_config.go
@@ -31,6 +31,8 @@ func init() {
 	clientLists["VSCode Cline"] = filepath.Join(os.Getenv("HOME"), "Library", "Application Support", "Code", "User", "globalStorage", "saoudrizwan.claude-dev", "settings", "cline_mcp_settings.json")
 	clientLists["Trae CN Cline"] = filepath.Join(os.Getenv("HOME"), "Library", "Application Support", "Trae CN", "User", "globalStorage", "saoudrizwan.claude-dev", "settings", "cline_mcp_settings.json")
 	clientLists["Trae Cline"] = filepath.Join(os.Getenv("HOME"), "Library", "Application Support", "Trae", "User", "globalStorage", "saoudrizwan.claude-dev", "settings", "cline_mcp_settings.json")
+	clientLists["Trae"] = filepath.Join(os.Getenv("HOME"), "Library", "Application Support", "Trae", "User", "mcp.json")
+	clientLists["Trae CN"] = filepath.Join(os.Getenv("HOME"), "Library", "Application Support", "Trae CN", "User", "mcp.json")
 	clientLists["VSCode Roo"] = filepath.Join(os.Getenv("HOME"), "Library", "Application Support", "Code", "User", "globalStorage", "rooveterinaryinc.roo-cline", "settings", "mcp_settings.json")
 	clientLists["Trae CN Roo"] = filepath.Join(os.Getenv("HOME"), "Library", "Application Support", "Trae CN", "User", "globalStorage", "rooveterinaryinc.roo-cline", "settings", "mcp_settings.json")
 	clientLists["Trae Roo"] = filepath.Join(os.Getenv("HOME"), "Library", "Application Support", "Trae", "User", "globalStorage", "rooveterinaryinc.roo-cline", "settings", "mcp_settings.json")

--- a/client/client_config_windows.go
+++ b/client/client_config_windows.go
@@ -29,6 +29,8 @@ func init() {
 	clientLists["VSCODE Cline"] = filepath.Join(os.Getenv("APPDATA"), "Code", "User", "globalStorage", "saoudrizwan.claude-dev", "settings", "cline_mcp_settings.json")
 	clientLists["Trae CN Cline"] = filepath.Join(os.Getenv("APPDATA"), "Trae CN", "User", "globalStorage", "saoudrizwan.claude-dev", "settings", "cline_mcp_settings.json")
 	clientLists["Trae Cline"] = filepath.Join(os.Getenv("APPDATA"), "Trae", "User", "globalStorage", "saoudrizwan.claude-dev", "settings", "cline_mcp_settings.json")
+	clientLists["Trae"] = filepath.Join(os.Getenv("APPDATA"), "Trae", "User", "mcp.json")
+	clientLists["Trae CN"] = filepath.Join(os.Getenv("APPDATA"), "Trae CN", "User", "mcp.json")
 	clientLists["VSCODE Roo Code"] = filepath.Join(os.Getenv("APPDATA"), "Code", "User", "globalStorage", "rooveterinaryinc.roo-cline", "settings", "mcp_settings.json")
 	clientLists["Trae CN Roo"] = filepath.Join(os.Getenv("APPDATA"), "Trae CN", "User", "globalStorage", "saoudrizwan.claude-dev", "settings", "mcp_settings.json")
 	clientLists["Trae Roo"] = filepath.Join(os.Getenv("APPDATA"), "Trae", "User", "globalStorage", "saoudrizwan.claude-dev", "settings", "mcp_settings.json")


### PR DESCRIPTION
This pull request introduces updates to the client configuration and server initialization logic to enhance functionality and improve compatibility across different platforms. The most important changes include modifying default server arguments and adding new client configuration paths for both macOS and Windows environments.

### Server configuration updates:
* Updated the default `Args` in the `NewMCPServerConfig` function to include `"-m"` and `"all"`, replacing the previously unused empty array. This change ensures that all modes are enabled by default when initializing the server. (`client/client.go`, [client/client.goL54-R54](diffhunk://#diff-bd3a55a72186f59e2e63efb4951573b2f9e4a7cc98086e922b0859f8ccc1dd09L54-R54))

### Client configuration updates:
* Added new configuration paths for `Trae` and `Trae CN` in the `clientLists` map for macOS, pointing to `mcp.json` files. This addition provides support for these clients with a simplified configuration file. (`client/client_config.go`, [client/client_config.goR34-R35](diffhunk://#diff-5bb8a51ea0a9cc95b06e9b870940ebed593bd6864b5e2e77d6cec085e201de94R34-R35))
* Added equivalent configuration paths for `Trae` and `Trae CN` in the `clientLists` map for Windows, ensuring cross-platform compatibility with the same `mcp.json` files. (`client/client_config_windows.go`, [client/client_config_windows.goR32-R33](diffhunk://#diff-bb26f7c83997799f6cdde45671aede1217d622bce555e131a7ac532b79c38bbaR32-R33))