### PR TITLE
feat: Add tool annotations for improved LLM tool understanding

### DIFF
--- a/pkg/services/browser/browser.go
+++ b/pkg/services/browser/browser.go
@@ -139,6 +139,8 @@ func (bs *BrowserServer) Init() error {
 	bs.AddTool(mcp.NewTool(
 		"browser_navigate",
 		mcp.WithDescription("Navigate to a URL"),
+		mcp.WithTitleAnnotation("Navigate Browser"),
+		mcp.WithDestructiveHintAnnotation(true),
 		mcp.WithString("url",
 			mcp.Description("URL to navigate to"),
 			mcp.Required(),
@@ -147,6 +149,8 @@ func (bs *BrowserServer) Init() error {
 	bs.AddTool(mcp.NewTool(
 		"browser_screenshot",
 		mcp.WithDescription("Take a screenshot of the current page or a specific element"),
+		mcp.WithTitleAnnotation("Take Screenshot"),
+		mcp.WithDestructiveHintAnnotation(true),
 		mcp.WithString("name",
 			mcp.Description("Name for the screenshot"),
 			mcp.Required(),
@@ -164,6 +168,8 @@ func (bs *BrowserServer) Init() error {
 	bs.AddTool(mcp.NewTool(
 		"browser_click",
 		mcp.WithDescription("Click an element on the page"),
+		mcp.WithTitleAnnotation("Click Element"),
+		mcp.WithDestructiveHintAnnotation(true),
 		mcp.WithString("selector",
 			mcp.Description("CSS selector for element to click"),
 			mcp.Required(),
@@ -172,6 +178,8 @@ func (bs *BrowserServer) Init() error {
 	bs.AddTool(mcp.NewTool(
 		"browser_fill",
 		mcp.WithDescription("Fill out an input field"),
+		mcp.WithTitleAnnotation("Fill Input"),
+		mcp.WithDestructiveHintAnnotation(true),
 		mcp.WithString("selector",
 			mcp.Description("CSS selector for input field"),
 			mcp.Required(),
@@ -184,6 +192,8 @@ func (bs *BrowserServer) Init() error {
 	bs.AddTool(mcp.NewTool(
 		"browser_select",
 		mcp.WithDescription("Select an element on the page with Select tag"),
+		mcp.WithTitleAnnotation("Select Option"),
+		mcp.WithDestructiveHintAnnotation(true),
 		mcp.WithString("selector",
 			mcp.Description("CSS selector for element to select"),
 			mcp.Required(),
@@ -196,6 +206,8 @@ func (bs *BrowserServer) Init() error {
 	bs.AddTool(mcp.NewTool(
 		"browser_hover",
 		mcp.WithDescription("Hover an element on the page"),
+		mcp.WithTitleAnnotation("Hover Element"),
+		mcp.WithDestructiveHintAnnotation(true),
 		mcp.WithString("selector",
 			mcp.Description("CSS selector for element to hover"),
 			mcp.Required(),
@@ -204,6 +216,8 @@ func (bs *BrowserServer) Init() error {
 	bs.AddTool(mcp.NewTool(
 		"browser_evaluate",
 		mcp.WithDescription("Execute JavaScript in the browser console"),
+		mcp.WithTitleAnnotation("Evaluate JavaScript"),
+		mcp.WithDestructiveHintAnnotation(true),
 		mcp.WithString("script",
 			mcp.Description("JavaScript code to execute"),
 			mcp.Required(),
@@ -213,6 +227,8 @@ func (bs *BrowserServer) Init() error {
 	bs.AddTool(mcp.NewTool(
 		"browser_debug_enable",
 		mcp.WithDescription("Enable JavaScript debugging"),
+		mcp.WithTitleAnnotation("Toggle Debugging"),
+		mcp.WithDestructiveHintAnnotation(true),
 		mcp.WithBoolean("enabled",
 			mcp.Description("Enable or disable debugging"),
 			mcp.Required(),
@@ -222,6 +238,8 @@ func (bs *BrowserServer) Init() error {
 	bs.AddTool(mcp.NewTool(
 		"browser_set_breakpoint",
 		mcp.WithDescription("Set a JavaScript breakpoint"),
+		mcp.WithTitleAnnotation("Set Breakpoint"),
+		mcp.WithDestructiveHintAnnotation(true),
 		mcp.WithString("url",
 			mcp.Description("URL of the script"),
 			mcp.Required(),
@@ -241,6 +259,8 @@ func (bs *BrowserServer) Init() error {
 	bs.AddTool(mcp.NewTool(
 		"browser_remove_breakpoint",
 		mcp.WithDescription("Remove a JavaScript breakpoint"),
+		mcp.WithTitleAnnotation("Remove Breakpoint"),
+		mcp.WithDestructiveHintAnnotation(true),
 		mcp.WithString("breakpointId",
 			mcp.Description("Breakpoint ID to remove"),
 			mcp.Required(),
@@ -250,16 +270,22 @@ func (bs *BrowserServer) Init() error {
 	bs.AddTool(mcp.NewTool(
 		"browser_pause",
 		mcp.WithDescription("Pause JavaScript execution"),
+		mcp.WithTitleAnnotation("Pause Execution"),
+		mcp.WithDestructiveHintAnnotation(true),
 	), bs.handlePause)
 
 	bs.AddTool(mcp.NewTool(
 		"browser_resume",
 		mcp.WithDescription("Resume JavaScript execution"),
+		mcp.WithTitleAnnotation("Resume Execution"),
+		mcp.WithDestructiveHintAnnotation(true),
 	), bs.handleResume)
 
 	bs.AddTool(mcp.NewTool(
 		"browser_get_callstack",
 		mcp.WithDescription("Get current call stack when paused"),
+		mcp.WithTitleAnnotation("Get Call Stack"),
+		mcp.WithReadOnlyHintAnnotation(true),
 	), bs.handleGetCallstack)
 	return nil
 }

--- a/pkg/services/command/command.go
+++ b/pkg/services/command/command.go
@@ -97,6 +97,8 @@ func (cs *CommandServer) Init() error {
 	cs.AddTool(mcp.NewTool(
 		"execute_command",
 		mcp.WithDescription("Execute a named command.Only support command execution on macOS and will strictly follow safety guidelines, ensuring that commands are safe and secure"),
+		mcp.WithTitleAnnotation("Execute Command"),
+		mcp.WithDestructiveHintAnnotation(true),
 		mcp.WithString("command",
 			mcp.Description("The command to execute"),
 			mcp.Required(),

--- a/pkg/services/filesystem/file_system.go
+++ b/pkg/services/filesystem/file_system.go
@@ -110,6 +110,8 @@ func (fs *FilesystemServer) Init() error {
 	// Register tool handlers
 	fs.AddTool(mcp.NewTool("read_file",
 		mcp.WithDescription("Read the complete contents of a file from the file system."),
+		mcp.WithTitleAnnotation("Read File"),
+		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithString("path",
 			mcp.Description("Relative path to the file to read"),
 			mcp.Required(),
@@ -119,6 +121,8 @@ func (fs *FilesystemServer) Init() error {
 	fs.AddTool(mcp.NewTool(
 		"write_file",
 		mcp.WithDescription("Create a new file or overwrite an existing file with new content."),
+		mcp.WithTitleAnnotation("Write File"),
+		mcp.WithDestructiveHintAnnotation(true),
 		mcp.WithString("path",
 			mcp.Description("Relative Path where to write the file"),
 			mcp.Required(),
@@ -132,6 +136,8 @@ func (fs *FilesystemServer) Init() error {
 	fs.AddTool(mcp.NewTool(
 		"list_directory",
 		mcp.WithDescription("Get a detailed listing of all files and directories in a specified path."),
+		mcp.WithTitleAnnotation("List Directory"),
+		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithString("path",
 			mcp.Description("Relative Path of the directory to list"),
 			mcp.Required(),
@@ -141,6 +147,8 @@ func (fs *FilesystemServer) Init() error {
 	fs.AddTool(mcp.NewTool(
 		"create_directory",
 		mcp.WithDescription("Create a new directory or ensure a directory exists."),
+		mcp.WithTitleAnnotation("Create Directory"),
+		mcp.WithDestructiveHintAnnotation(true),
 		mcp.WithString("path",
 			mcp.Description("Relative Path of the directory to create"),
 			mcp.Required(),
@@ -150,6 +158,8 @@ func (fs *FilesystemServer) Init() error {
 	fs.AddTool(mcp.NewTool(
 		"move_file",
 		mcp.WithDescription("Move or rename files and directories."),
+		mcp.WithTitleAnnotation("Move File"),
+		mcp.WithDestructiveHintAnnotation(true),
 		mcp.WithString("source",
 			mcp.Description("Relative Source path of the file or directory"),
 			mcp.Required(),
@@ -163,6 +173,8 @@ func (fs *FilesystemServer) Init() error {
 	fs.AddTool(mcp.NewTool(
 		"search_files",
 		mcp.WithDescription("Recursively search for files and directories matching a pattern."),
+		mcp.WithTitleAnnotation("Search Files"),
+		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithString("path",
 			mcp.Description("Relative Starting path for the search"),
 			mcp.Required(),
@@ -176,6 +188,8 @@ func (fs *FilesystemServer) Init() error {
 	fs.AddTool(mcp.NewTool(
 		"get_file_info",
 		mcp.WithDescription("Retrieve detailed metadata about a file or directory."),
+		mcp.WithTitleAnnotation("Get File Info"),
+		mcp.WithReadOnlyHintAnnotation(true),
 		mcp.WithString("path",
 			mcp.Description("Relative Path to the file or directory"),
 			mcp.Required(),
@@ -185,6 +199,8 @@ func (fs *FilesystemServer) Init() error {
 	fs.AddTool(mcp.NewTool(
 		"list_allowed_directories",
 		mcp.WithDescription("Returns the list of directories that this server is allowed to access."),
+		mcp.WithTitleAnnotation("List Allowed Directories"),
+		mcp.WithReadOnlyHintAnnotation(true),
 	), fs.handleListAllowedDirectories)
 	return nil
 }


### PR DESCRIPTION
## Summary

Adds MCP tool annotations (`readOnlyHint`, `destructiveHint`, `title`) to all 22 tools to help LLMs better understand tool behavior and make safer decisions about tool execution.

## Changes

### Command Service (1 tool)
- `execute_command`: Destructive (executes shell commands)

### Browser Service (13 tools)
| Tool | Classification |
|------|----------------|
| `browser_navigate` | Destructive (navigates browser) |
| `browser_screenshot` | Destructive (saves file to disk) |
| `browser_click` | Destructive (interacts with page) |
| `browser_fill` | Destructive (enters data) |
| `browser_select` | Destructive (changes selection) |
| `browser_hover` | Destructive (triggers events) |
| `browser_evaluate` | Destructive (executes JavaScript) |
| `browser_debug_enable` | Destructive (modifies debugger) |
| `browser_set_breakpoint` | Destructive (sets breakpoint) |
| `browser_remove_breakpoint` | Destructive (removes breakpoint) |
| `browser_pause` | Destructive (pauses execution) |
| `browser_resume` | Destructive (resumes execution) |
| `browser_get_callstack` | **Read-only** (observes state) |

### Filesystem Service (8 tools)
| Tool | Classification |
|------|----------------|
| `read_file` | Read-only |
| `list_directory` | Read-only |
| `search_files` | Read-only |
| `get_file_info` | Read-only |
| `list_allowed_directories` | Read-only |
| `write_file` | Destructive |
| `create_directory` | Destructive |
| `move_file` | Destructive |

## Why This Matters

- Annotations provide semantic metadata that helps LLMs understand tool behavior
- LLMs can make better decisions about when to use tools and in what order
- Enables safer tool execution by distinguishing read-only from destructive operations
- MCP clients (like Claude Code) can auto-approve read-only tools without user confirmation

## Testing

- [x] `go build ./...` passes
- [x] All 22 tools annotated with appropriate hints
- [x] Using existing mcp-go v0.29.0 annotation support (no SDK upgrade needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)